### PR TITLE
close floating windows when disconnected

### DIFF
--- a/src/ed.js
+++ b/src/ed.js
@@ -305,7 +305,7 @@ D.Ed.prototype={
   },
   onbeforeunload:function(e){ //called when the user presses [X] on the OS window
     var ed=this
-    if(D.prf.floating()){e.returnValue=false;}
+    if(D.prf.floating()&&D.ide.connected){e.returnValue=false;}
     if(ed.ide.dead){D.nww&&D.nww.close(true)} //force close window
     else if(ed.tc||ed.cm.getValue()===ed.oText&&''+ed.getStops()===''+ed.oStop){ed.EP(ed.cm)}
     else{

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -18,7 +18,7 @@ D.IPC_Client=function(winId){
     });
     D.ipc.of.ride_master.on('disconnect',function(){
       D.ipc.log('disconnected from ride_master'.notice);
-      close();
+      D.ide.connected=0;close();
     });
     D.ipc.of.ride_master.on('die',()=>D.ed.die());
     D.ipc.of.ride_master.on('processAutocompleteReply',x=>D.ed.processAutocompleteReply(x));


### PR DESCRIPTION
When RIDE disconnects from a running interpreter, floating windows are also closed