### PR TITLE
ShowHTML inline using viewzone, #229

### DIFF
--- a/src/ide.js
+++ b/src/ide.js
@@ -611,29 +611,48 @@ D.IDE = function IDE(opts = {}) {
       }
     },
     ShowHTML(x) {
-      if (D.el) {
-        let w = ide.w3500;
-        if (!w || w.isDestroyed()) {
-          ide.w3500 = new D.el.BrowserWindow({
-            width: 800,
-            height: 500,
-          });
-          w = ide.w3500;
-        }
-        w.loadURL(`file://${__dirname}/empty.html`);
-        w.webContents.executeJavaScript(`document.body.innerHTML=${JSON.stringify(x.html)}`);
-        w.setTitle(x.title || '3500 I-beam');
-      } else {
-        const init = () => {
-          ide.w3500.document.body.innerHTML = x.html;
-          ide.w3500.document.getElementsByTagName('title')[0].innerHTML = D.util.esc(x.title || '3500⌶');
-        };
-        if (ide.w3500 && !ide.w3500.closed) {
-          ide.w3500.focus(); init();
+      if (x.title) {
+        if (D.el) {
+          let w = ide.w3500;
+          if (!w || w.isDestroyed()) {
+            ide.w3500 = new D.el.BrowserWindow({
+              width: 800,
+              height: 500,
+            });
+            w = ide.w3500;
+          }
+          w.loadURL(`file://${__dirname}/empty.html`);
+          w.webContents.executeJavaScript(`document.body.innerHTML=${JSON.stringify(x.html)}`);
+          w.setTitle(x.title || '3500 I-beam');
         } else {
-          ide.w3500 = window.open('empty.html', '3500 I-beam', 'width=800,height=500');
-          ide.w3500.onload = init;
+          const init = () => {
+            ide.w3500.document.body.innerHTML = x.html;
+            ide.w3500.document.getElementsByTagName('title')[0].innerHTML = D.util.esc(x.title || '3500⌶');
+          };
+          if (ide.w3500 && !ide.w3500.closed) {
+            ide.w3500.focus(); init();
+          } else {
+            ide.w3500 = window.open('empty.html', '3500 I-beam', 'width=800,height=500');
+            ide.w3500.onload = init;
+          }
         }
+      } else {
+        const { me } = ide.wins['0'];
+        const html = x.html.trim();
+        const template = document.createElement('template');
+        template.innerHTML = html;
+        const node = ide.dom.appendChild(template.content.firstChild);
+        const height = node.clientHeight;
+        ide.dom.removeChild(node);
+        template.innerHTML = html;
+
+        me.changeViewZones((accessor) => {
+          accessor.addZone({
+            domNode: template.content.firstChild,
+            afterLineNumber: me.getModel().getLineCount() - 1,
+            heightInPx: height,
+          });
+        });
       }
     },
     OptionsDialog(x) {


### PR DESCRIPTION
Show HTML inline (3600⌶). FIrst pass on this is putting html inline if no title is provided, otherwise creates window as before. I noticed that RIDE currently suppresses almost all standard styling, so you need to provide stylesheet with the html to make it render properly.

Tested with Morten's original sample:
```apl
    ∇ SPHistogram times;heading;renderHtml;sp;svg;z        
[1]    heading←'Reaction Times'                             
[2]    renderHtml←3500⌶ ⍝ Render HTML in Window             
[3]                                                          
[4]    :If 0=⎕NC'#.SharpPlot' ⋄ #.⎕CY'sharpplot.dws' ⋄ :EndIf
[5]                                                         
[6]    sp←⎕NEW #.SharpPlot                                  
[7]    sp.Heading←heading                                   
[8]    sp.ClassInterval←25                                  
[9]    sp.SetXTickMarks 25                                  
[10]   sp.HistogramStyle←#.HistogramStyles.SurfaceShading   
[11]   sp.SetFillStyles #.FillStyle.Opacity30               
[12]   sp.DrawHistogram⊂times                               
[13]   sp.SetMarkers #.Marker.UpTick                        
[14]   sp.SetPenWidths 1                                    
[15]   sp.SetMarkerScales 3                                 
[16]   sp.DrawScatterPlot(times×0)(times)                   
[17]                                                        
[18]   svg←sp.RenderSvg #.SvgMode.FixedAspect               
[19]   z←renderHtml svg                                      
     ∇                                                      
 
        SPHistogram 500+?100⍴500 ⍝ In a RIDE session
```