### PR TITLE
allow replies when prompttype 0

### DIFF
--- a/src/cn.js
+++ b/src/cn.js
@@ -954,7 +954,7 @@
   module.exports = () => {
     D.send = (x, y) => {
       if (D.ide && !D.ide.promptType
-        && !/Interrupt$|TreeList/.test(x)) return;
+        && !/Interrupt$|TreeList|Reply/.test(x)) return;
       sendEach([JSON.stringify([x, y])]);
     };
     const a = rq('electron').remote.process.argv;


### PR DESCRIPTION
Replies to dialog prompts from interpreter should be sent even when prompt type is 0.