### PR TITLE
Use GetSyntaxInformation if supported by interpreter

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -534,6 +534,18 @@ If sent to a Process manager, `remoteId` is a list of remote IDs returned by
 ["ReplyGetDetailedInformation",{"information":[i0,i1,...]}] // anything -> anything
 ```
 
+# GetSyntaxInformation
+RIDE can request Syntax information specific to the version of the interpreter being run.
+<a name=GetSyntaxInformation></a>
+```json
+["GetHelpInformation",{}] // RIDE -> Interpreter
+```
+
+<a name=ReplyGetSyntaxInformation></a>
+```json
+["ReplyGetSyntaxInformation",{"url":"https://help.dyalog.com/18.1/#Language/Symbols/Plus%20Sign.htm"}] // Interpreter -> RIDE
+```
+
 # Proposed extensions
 * related to the process manager
 ```

--- a/index.html
+++ b/index.html
@@ -717,6 +717,7 @@
 <script src=src/ipc.js        ></script>
 <script src=src/mon_apl.js    ></script>
 <script src=src/init.js       ></script>
+<script src=src/syntax_info.js></script>
 
 </body>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2014,16 +2014,10 @@
         "typedarray": "^0.0.6"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4019,15 +4013,15 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -4037,6 +4031,21 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -4127,9 +4136,9 @@
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -5419,9 +5428,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -6038,9 +6047,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "language-subtag-registry": {
@@ -6603,9 +6612,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -6917,9 +6926,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {
@@ -6959,20 +6968,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "mkdirp-classic": {
@@ -10254,12 +10255,13 @@
       "dev": true
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "zip-stream": {

--- a/src/ide.js
+++ b/src/ide.js
@@ -27,6 +27,7 @@ D.IDE = function IDE(opts = {}) {
   if (ide.floating) {
     ide.connected = 1;
     this._focusedWin = null;
+    ide.ipc.emit('getSyntax');
     Object.defineProperty(ide, 'focusedWin', {
       set(w) {
         ide.ipc.emit('focusedWin', w.id);
@@ -41,6 +42,7 @@ D.IDE = function IDE(opts = {}) {
     I.sb_threads.hidden = !1;
     ide.wins[0] = new D.Se(ide);
     D.wins = ide.wins;
+    D.send('GetSyntaxInformation',{});
 
     ide.focusedWin = ide.wins['0']; // last focused window, it might not have the focus right now
     ide.switchWin = (x) => { // x: +1 or -1
@@ -51,7 +53,6 @@ D.IDE = function IDE(opts = {}) {
         wins[k].hasFocus() && (i = a.length);
         a.push(wins[k]);
       });
-      D.send('GetSyntaxInformation',{});
       const j = i < 0 ? 0 : (i + a.length + x) % a.length;
       const w = a[j];
       if (!w.bwId) D.elw.focus();
@@ -540,6 +541,7 @@ D.IDE = function IDE(opts = {}) {
     },
     ReplyGetSyntaxInformation(x) {
       D.ParseSyntaxInformation(x);
+      D.ipc.server && D.ipc.server.broadcast('syntax', D.syntax);
     },
     ValueTip(x) { ide.wins[x.token].ValueTip(x); },
     SetHighlightLine(x) { 

--- a/src/ide.js
+++ b/src/ide.js
@@ -51,6 +51,7 @@ D.IDE = function IDE(opts = {}) {
         wins[k].hasFocus() && (i = a.length);
         a.push(wins[k]);
       });
+      D.send('GetSyntaxInformation',{});
       const j = i < 0 ? 0 : (i + a.length + x) % a.length;
       const w = a[j];
       if (!w.bwId) D.elw.focus();
@@ -533,8 +534,11 @@ D.IDE = function IDE(opts = {}) {
     GotoWindow(x) { const w = ide.wins[x.win]; w && w.focus(); },
     WindowTypeChanged(x) { return ide.wins[x.win].setTC(x.tracer); },
     ReplyGetAutocomplete(x) { const w = ide.wins[x.token]; w && w.processAutocompleteReply(x); },
+    ReplyGetSyntaxInformation(x) {
+      D.ParseSyntaxInformation(x);
+    },
     ValueTip(x) { ide.wins[x.token].ValueTip(x); },
-    SetHighlightLine(x) {
+    SetHighlightLine(x) { 
       const w = D.wins[x.win];
       w.SetHighlightLine(x.line, ide.hadErr);
       ide.hadErr > 0 && (ide.hadErr -= 1);
@@ -722,7 +726,9 @@ D.IDE = function IDE(opts = {}) {
     },
     ReplyGetLog(x) { ide.wins[0].add(x.result.join('\n')); ide.bannerDone = 0; },
     UnknownCommand(x) {
-      if (x.name === 'ClearTraceStopMonitor') toastr.warning('Clear all trace/stop/monitor not supported by the interpreter');
+      if (x.name === 'ClearTraceStopMonitor') {
+        toastr.warning('Clear all trace/stop/monitor not supported by the interpreter');
+      }
     },
   };
 };

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -52,6 +52,7 @@
           });
         }, 100);
       });
+      rm.on('syntax', (x) => { D.syntax = x; });
     });
   };
 
@@ -170,6 +171,9 @@
       });
       srv.on('pfKey', x => D.ide.pfKey(x));
       srv.on('getStats', () => D.ide.getStats());
+      srv.on('getSyntax', (data, socket) => {
+        srv.emit(socket, 'syntax', D.syntax);
+      });
       srv.on('getUnsavedReply', (data) => {
         if (!D.pendingEdit) return;
         Object.keys(data).forEach((k) => {

--- a/src/mon_apl.js
+++ b/src/mon_apl.js
@@ -7,41 +7,37 @@
   // /(\w+|\(\w+ +(\w+)(?: +\w+)?\)) *(?:\w+|\( *\w+(?: +\w+)* *\))?$/
   const tradFnRE = RegExp(`(${name}|\\( *${name} +(${name})(?: +${name})? *\\)) *(?:${name}|\\( *${name}(?: +${name})* *\\))? *$`);
   const end = '(?:⍝|$)';
-  const restartBlock = '|:else|:elseif|:andif|:orif';
-  const startBlock = ':class|:disposable|:for|:hold|:if|:interface|:namespace'
-    + `|:property|:repeat|:section|:select|:trap|:while|:with${restartBlock}`;
-  const endBlock = ':end|:endclass|:enddisposable|:endfor|:endhold|:endif|:endinterface'
-    + '|:endnamespace|:endproperty|:endrepeat|:endsection|:endselect|:endtrap'
-    + `|:endwhile|:endwith|:until${restartBlock}`;
   D.wordSeparators = `${D.informal.slice(0, -26).map(x => x[0]).join('').replace(/[⎕∆⍙]/g, '')}()[]{}%£#;:'"\`$^`;
 
-  const aplConfig = {
-    comments: {
-      lineComment: '⍝',
-    },
-    brackets: [
-      ['{', '}'],
-      ['[', ']'],
-      ['(', ')'],
-    ],
-    autoClosingPairs: [
-      { open: '{', close: '}' },
-      { open: '[', close: ']' },
-      { open: '(', close: ')' },
-    ],
-    surroundingPairs: [
-      { open: '{', close: '}' },
-      { open: '[', close: ']' },
-      { open: '(', close: ')' },
-      { open: '"', close: '"' },
-      { open: '\'', close: '\'' },
-    ],
-    indentationRules: {
-      decreaseIndentPattern: RegExp(`^((?!.*?⍝).*)?\\s*(${endBlock})\\b.*$`, 'i'),
-      increaseIndentPattern: RegExp(`^(?:(?!⍝).)*(${startBlock})\\b.*$`, 'i'),
-      unIndentedLinePattern: /^\s*⍝.*$/,
-    },
-    wordPattern: RegExp(name),
+  function aplConfig() {
+    return {
+      comments: {
+        lineComment: '⍝',
+      },
+      brackets: [
+        ['{', '}'],
+        ['[', ']'],
+        ['(', ')'],
+      ],
+      autoClosingPairs: [
+        { open: '{', close: '}' },
+        { open: '[', close: ']' },
+        { open: '(', close: ')' },
+      ],
+      surroundingPairs: [
+        { open: '{', close: '}' },
+        { open: '[', close: ']' },
+        { open: '(', close: ')' },
+        { open: '"', close: '"' },
+        { open: '\'', close: '\'' },
+      ],
+      indentationRules: {
+        decreaseIndentPattern: RegExp(`^((?!.*?⍝).*)?\\s*(${D.syntax.endBlock})\\b.*$`, 'i'),
+        increaseIndentPattern: RegExp(`^(?:(?!⍝).)*(${D.syntax.startBlock})\\b.*$`, 'i'),
+        unIndentedLinePattern: /^\s*⍝.*$/,
+      },
+      wordPattern: RegExp(name),
+    };
   };
 
   const aplSessionConfig = {
@@ -177,7 +173,6 @@
       let tkn;
       let s;
 
-      const sysvar = '⎕avu|⎕ct|⎕dct|⎕div|⎕fr|⎕io|⎕lx|⎕ml|⎕path|⎕pp|⎕pw|⎕rl|⎕rtl|⎕sm|⎕tname|⎕trap|⎕using|⎕wsid|⎕wx';
       const localRE = RegExp(`( *)(;)( *)(${D.syntax.sysvar}|${name})( *)(⍝?)`, 'i');
       const localVars = () => {
         let m;
@@ -1021,7 +1016,7 @@
       extensions: ['.dyapp', '.dyalog'],
     });
     ml.setTokensProvider('apl', aplTokens);
-    ml.setLanguageConfiguration('apl', aplConfig);
+    ml.setLanguageConfiguration('apl', aplConfig());
     ml.registerCompletionItemProvider('apl', aplCompletions(D.prf.prefixKey()));
     D.prf.prefixKey(x => ml.registerCompletionItemProvider('apl', aplCompletions(x)));
     ml.registerHoverProvider('apl', aplHover);

--- a/src/syntax_info.js
+++ b/src/syntax_info.js
@@ -1,0 +1,57 @@
+// syntax_info.js
+{
+    D.syntax = {
+
+        sysfns: ' a á af ai an arbin arbout arg at av avu base c class clear cmd cr cs csv ct cy d dct df div dl dm dmx dq dr dt ea ec ed em en env es et ex exception export fappend favail fc fchk fcopy fcreate fdrop ferase fhist fhold fix flib fmt fnames fnums fprops fr frdac frdci fread frename freplace fresize fsize fstac fstie ftie funtie fx inp instances io json kl l lc load lock lx map mkdir ml monitor na nappend nc ncopy ncreate ndelete nerase new nexists nget ninfo nl nlock nmove nnames nnums nparts nput nq nr nread nrename nreplace nresize ns nsi nsize ntie null nuntie nxlate off opt or path pfkey pp pr profile ps pt pw r refs rl rsi rtl s save sd se sh shadow si signal size sm sr src stack state stop svc sve svo svq svr svs syl tc tcnums tf tget this tid tkill tname tnums tpool tput trace trap treq ts tsync tz ucs ul using vfi vr wa wc wg wn ws wsid wx x xml xsi xt'.split(' '),
+        // However, some of these are not present in the object returned by the ReplyGetSyntaxInformation message:
+        //      af arg ea ec env es et fc inp l pr ps pt sve syl tf tz ul x                            
+        
+        scmd: ('classes clear cmd continue copy cs drop ed erase events fns holds intro lib load methods ns objects obs off ops pcopy props reset save sh sic si sinl tid vars wsid xload').split(' '),
+        
+        // localisable system variables, i.e. all but ⎕dmx ⎕se
+        sysvar:  '⎕avu|⎕ct|⎕dct|⎕div|⎕fr|⎕io|⎕lx|⎕ml|⎕path|⎕pp|⎕pw|⎕rl|⎕rtl|⎕sm|⎕tname|⎕trap|⎕using|⎕wsid|⎕wx',
+    
+        // « and » prevent tolerance for extra whitespace
+        // _ stands for «' '» (space as an APL character literal)
+        idioms: '⍴⍴ /⍳ /⍳⍴ ⊃¨⊂ {} {⍺} {⍵} {⍺⍵} {0} {0}¨ ,/ ⊃⌽ ↑⌽ ⊃⌽, ↑⌽, 0=⍴ 0=⍴⍴ 0=≡ «⎕AV»⍳ ↓⍉↑ ↓⍉⊃ +/∧\\ +/∧\\_= {(↓⍺)⍳↓⍵} ~∘_¨↓ {(+/∨\\_≠⌽⍵)↑¨↓⍵} ∧\\_= {(∨\\_≠⍵)/⍵} {(+/∧\\_=⍵)↓⍵} 1=≡ 1=≡, 0∊⍴ ~0∊⍴ ⊃∘⍴¨ ↑∘⍴¨ ,← {⍵[⍋⍵]} {⍵[⍒⍵]} {⍵[⍋⍵;]} {⍵[⍒⍵;]} ⍪← ⍪/ *○ ⊣/ ⊢/ ⊣⌿ ⊢⌿ 0=⊃⍴ 0≠⊃⍴ ⌊«0.5»+ ≢⍴ ↓⍨← {(⊂⍋⍵)⌷⍵} {(⊂⍒⍵)⌷⍵}'.split(' '),
+    
+        restartBlock: '|:else|:elseif|:andif|:orif',
+        startBlock: ':class|:disposable|:for|:hold|:if|:interface|:namespace|:property|:repeat|:section|:select|:trap|:while|:with${restartBlock}',
+        endBlock: ':end|:endclass|:enddisposable|:endfor|:endhold|:endif|:endinterface|:endnamespace|:endproperty|:endrepeat|:endsection|:endselect|:endtrap|:endwhile|:endwith|:until${restartBlock}',
+    };
+    
+    function escRE(s) { return s.replace(/[()[\]{}.?+*/\\^$|]/g, x => `\\${x}`); }
+    function escIdiom(s) {
+        return s.replace(/«(.*?)»|(.)/g, (_, g1, g2) => { const g = g1 || g2; return ` *${(g === '_' ? "' '" : escRE(g))}`; }).slice(2);
+    }
+    
+    function defineSyntaxRegex(){
+        D.syntax.idiomsRE = RegExp(`^(?:${D.syntax.idioms.sort((x, y) => y.length - x.length).map(escIdiom).join('|')})`, 'i');
+
+    }
+
+    D.ParseSyntaxInformation = function (x) {
+         // If a SyntaxInfo object is returned, use it:
+        // We need to process each of these to remove all of the lovely formatting that John provides.
+        D.syntax.sysfns = [
+            ... x.quadcons, 
+            ... x.quadfns, 
+            ... x.quadops, 
+            ... x.quadvars.flat(3)
+        ].map(s => s.slice(1).toLowerCase());
+        
+        
+        D.syntax.scmd = x.syscommands.map(s => s.slice(1).toLowerCase());
+        
+        D.syntax.sysvar = x.quadvars.flat(3).map(s => s.slice(1).toLowerCase());
+        
+        D.syntax.idioms = x.idioms;     // The ReplyGetSyntaxInformation message already returns a list of strings formatted as required.
+
+        //// The ReplyGetSyntaxInformation message does not return these in the same format, just a single 'keywords' array.
+        //D.restartBlock = ;//???
+        //D.startBlock = ;//???
+        //D.endBlock = ;//???
+
+    };
+
+}

--- a/src/syntax_info.js
+++ b/src/syntax_info.js
@@ -1,7 +1,6 @@
 // syntax_info.js
 {
     D.syntax = {
-
         sysfns: ' a á af ai an arbin arbout arg at av avu base c class clear cmd cr cs csv ct cy d dct df div dl dm dmx dq dr dt ea ec ed em en env es et ex exception export fappend favail fc fchk fcopy fcreate fdrop ferase fhist fhold fix flib fmt fnames fnums fprops fr frdac frdci fread frename freplace fresize fsize fstac fstie ftie funtie fx inp instances io json kl l lc load lock lx map mkdir ml monitor na nappend nc ncopy ncreate ndelete nerase new nexists nget ninfo nl nlock nmove nnames nnums nparts nput nq nr nread nrename nreplace nresize ns nsi nsize ntie null nuntie nxlate off opt or path pfkey pp pr profile ps pt pw r refs rl rsi rtl s save sd se sh shadow si signal size sm sr src stack state stop svc sve svo svq svr svs syl tc tcnums tf tget this tid tkill tname tnums tpool tput trace trap treq ts tsync tz ucs ul using vfi vr wa wc wg wn ws wsid wx x xml xsi xt'.split(' '),
         // However, some of these are not present in the object returned by the ReplyGetSyntaxInformation message:
         //      af arg ea ec env es et fc inp l pr ps pt sve syl tf tz ul x                            
@@ -14,11 +13,12 @@
         // « and » prevent tolerance for extra whitespace
         // _ stands for «' '» (space as an APL character literal)
         idioms: '⍴⍴ /⍳ /⍳⍴ ⊃¨⊂ {} {⍺} {⍵} {⍺⍵} {0} {0}¨ ,/ ⊃⌽ ↑⌽ ⊃⌽, ↑⌽, 0=⍴ 0=⍴⍴ 0=≡ «⎕AV»⍳ ↓⍉↑ ↓⍉⊃ +/∧\\ +/∧\\_= {(↓⍺)⍳↓⍵} ~∘_¨↓ {(+/∨\\_≠⌽⍵)↑¨↓⍵} ∧\\_= {(∨\\_≠⍵)/⍵} {(+/∧\\_=⍵)↓⍵} 1=≡ 1=≡, 0∊⍴ ~0∊⍴ ⊃∘⍴¨ ↑∘⍴¨ ,← {⍵[⍋⍵]} {⍵[⍒⍵]} {⍵[⍋⍵;]} {⍵[⍒⍵;]} ⍪← ⍪/ *○ ⊣/ ⊢/ ⊣⌿ ⊢⌿ 0=⊃⍴ 0≠⊃⍴ ⌊«0.5»+ ≢⍴ ↓⍨← {(⊂⍋⍵)⌷⍵} {(⊂⍒⍵)⌷⍵}'.split(' '),
-    
-        restartBlock: '|:else|:elseif|:andif|:orif',
-        startBlock: ':class|:disposable|:for|:hold|:if|:interface|:namespace|:property|:repeat|:section|:select|:trap|:while|:with${restartBlock}',
-        endBlock: ':end|:endclass|:enddisposable|:endfor|:endhold|:endif|:endinterface|:endnamespace|:endproperty|:endrepeat|:endsection|:endselect|:endtrap|:endwhile|:endwith|:until${restartBlock}',
     };
+
+    D.syntax.restartBlock = '|:else|:elseif|:andif|:orif';
+    D.syntax.startBlock = `:class|:disposable|:for|:hold|:if|:interface|:namespace|:property|:repeat|:section|:select|:trap|:while|:with${D.syntax.restartBlock}`;
+    D.syntax.endBlock = `:end|:endclass|:enddisposable|:endfor|:endhold|:endif|:endinterface|:endnamespace|:endproperty|:endrepeat|:endsection|:endselect|:endtrap|:endwhile|:endwith|:until${D.syntax.restartBlock}`;
+    
     
     function escRE(s) { return s.replace(/[()[\]{}.?+*/\\^$|]/g, x => `\\${x}`); }
     function escIdiom(s) {
@@ -27,7 +27,6 @@
     
     function defineSyntaxRegex(){
         D.syntax.idiomsRE = RegExp(`^(?:${D.syntax.idioms.sort((x, y) => y.length - x.length).map(escIdiom).join('|')})`, 'i');
-
     }
 
     D.ParseSyntaxInformation = function (x) {
@@ -37,15 +36,16 @@
             ... x.quadcons, 
             ... x.quadfns, 
             ... x.quadops, 
-            ... x.quadvars.flat(3)
+            ... x.quadvars.flat()
         ].map(s => s.slice(1).toLowerCase());
         
         
         D.syntax.scmd = x.syscommands.map(s => s.slice(1).toLowerCase());
         
-        D.syntax.sysvar = x.quadvars.flat(3).map(s => s.slice(1).toLowerCase());
+        D.syntax.sysvar = x.quadvars.flat().join('|').toLowerCase();
         
         D.syntax.idioms = x.idioms;     // The ReplyGetSyntaxInformation message already returns a list of strings formatted as required.
+        defineSyntaxRegex();
 
         //// The ReplyGetSyntaxInformation message does not return these in the same format, just a single 'keywords' array.
         //D.restartBlock = ;//???
@@ -53,5 +53,5 @@
         //D.endBlock = ;//???
 
     };
-
+    defineSyntaxRegex();
 }


### PR DESCRIPTION
Use new protocol command GetSyntaxInformation if supported by the interpreter, to make syntax highlighting more specific to the interpreter it is connected to.