### PR TITLE
Prevent prompt when LS or PS characters are entered in session/editor

### DIFF
--- a/src/ed.js
+++ b/src/ed.js
@@ -67,6 +67,8 @@
       useTabStops: false,
       wordBasedSuggestions: false,
       wordSeparators: D.wordSeparators,
+      unusualLineTerminators: 'off',   // iss646: Prevent message prompt about unusual line endings
+      
     });
     ed.me = me;
     ed.me_ready = new Promise((resolve) => {

--- a/src/se.js
+++ b/src/se.js
@@ -56,6 +56,7 @@
       wordBasedSuggestions: false,
       wordSeparators: D.wordSeparators,
       wordWrap: D.prf.wrap() ? 'on' : 'off',
+      unusualLineTerminators: 'off',  // iss646: Prevent message prompt about unusual line endings
     });
     se.me = me;
     se.me_ready = new Promise((resolve) => {


### PR DESCRIPTION
Set the Monaco Editor unusualLineTerminators properties to 'off' instead of defaulting to 'prompt' in se.js and ed.js