### PR TITLE
don't return dom element on opening protocol log

### DIFF
--- a/src/km.js
+++ b/src/km.js
@@ -212,7 +212,7 @@
       w.loadURL(`file://${__dirname}/empty.html`);
       w.webContents.executeJavaScript('var d = document, h=d.documentElement, b=d.body, e=d.createElement("div");'
                                     + 'b.style.fontFamily="monospace";b.style.overflow="scroll";'
-                                    + 'e.style.whiteSpace="pre";b.appendChild(e)');
+                                    + 'e.style.whiteSpace="pre";!!b.appendChild(e);');
       const f = (x) => {
         const t = JSON.stringify(`${x}\n`);
         w.webContents.executeJavaScript(`e.textContent += ${t}; h.scrollTop = h.scrollHeight`);


### PR DESCRIPTION
Electron 11 uses different serializer for data transferred between renderer and main which brought to light an unintentional response from Protocol window (DOM element returned as result of opening a new window).