### PR TITLE
allow autocomplete to overflow outside session

### DIFF
--- a/src/se.js
+++ b/src/se.js
@@ -33,6 +33,7 @@
       folding: false,
       fontFamily: 'apl',
       fontSize: fs,
+      fixedOverflowWidgets: true,
       glyphMargin: se.breakpoints,
       iconsInSuggestions: false,
       language: 'apl-session',


### PR DESCRIPTION
New monaco feature that allows the list of the autocomplete widget to overflow and show outside the session window