### PR TITLE
change status window to non-modal

### DIFF
--- a/src/ide.js
+++ b/src/ide.js
@@ -759,6 +759,7 @@ D.IDE.prototype = {
     ide.dead = 1;
     ide.connected = 0;
     ide.dom.className += ' disconnected';
+    ide.wStatus && ide.wStatus.close();
     Object.keys(ide.wins).forEach((k) => { ide.wins[k].die(); });
   },
   updPW(x) { this.wins[0] && this.wins[0].updPW(x); },

--- a/src/ide.js
+++ b/src/ide.js
@@ -720,7 +720,6 @@ D.IDE = function IDE(opts = {}) {
         ide.wStatus = new D.el.BrowserWindow({
           width: 600,
           height: 400,
-          parent: D.elw,
           webPreferences: {
             contextIsolation: true,
             nodeIntegration: false,


### PR DESCRIPTION
Status window no longer modal. Should not steal focus from other application windows either (need to check on linux).