### PR TITLE
Clear selection on double-click

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,6 +546,7 @@
       </p>
       <hr>
       <h2>Other</h2>
+      <p><label class=cb_label><input id=code_dce  type=checkbox>Double click to edit</label></p>
       <p><label class=cb_label><input id=code_sqp   type=checkbox>Show <u>q</u>uit prompt</label></p>
       <p><label class=cb_label><input id=code_set   type=checkbox>Show toolbar in editor/trace windows</label></p>
       <p><label class=cb_label><input id=code_coq  type=checkbox>Connect on quit</label></p>

--- a/src/ed.js
+++ b/src/ed.js
@@ -107,6 +107,7 @@
         if (e.event.timestamp - mouseTS < 400 && mouseL === p.lineNumber && mouseC === p.column) {
           e.event.preventDefault(); e.event.stopPropagation();
           ed.ED(me);
+          me.setPosition(p);
         }
         mouseL = p.lineNumber; mouseC = p.column; mouseTS = e.event.timestamp;
       }

--- a/src/ed.js
+++ b/src/ed.js
@@ -106,8 +106,10 @@
         || (ed.isReadOnly && t.type === mt.CONTENT_EMPTY)) {
         if (e.event.timestamp - mouseTS < 400 && mouseL === p.lineNumber && mouseC === p.column) {
           e.event.preventDefault(); e.event.stopPropagation();
-          ed.ED(me);
-          me.setPosition(p);
+          if (D.prf.doubleClickToEdit()) {
+            ed.ED(me);
+            me.setPosition(p);
+          }
         }
         mouseL = p.lineNumber; mouseC = p.column; mouseTS = e.event.timestamp;
       }

--- a/src/prf.js
+++ b/src/prf.js
@@ -17,6 +17,7 @@ D.prf = {};
   ['colourSchemes',      []],//objects describing user-defined colour schemes
   ['confirmations',      {}],//saved responses to TaskDialog questions
   ['connectOnQuit',      0], // open connection page when active session ends
+  ['doubleClickToEdit',  1], // whether double clicking a function name in session or editor opens an editor on that function
   ['floating',           0], //floating editor and tracer windows
   ['floatSingle',        1], //create single floating edit window
   ['fold',               1], //code folding

--- a/src/prf_code.js
+++ b/src/prf_code.js
@@ -1,5 +1,6 @@
 {
   // Preferences > Code
+  // Is this now Preferences > General?
 
   let q; // DOM elements whose ids start with "code_", keyed by the rest of the id
   D.prf_tabs.code = {
@@ -67,6 +68,7 @@
       q.ai.onchange();
       q.ac.onchange();
       q.ilf.onchange();
+      q.dce.checked = !!p.doubleClickToEdit();
     },
     activate() { q.ai.focus(); },
     save() {
@@ -96,6 +98,7 @@
       p.squiggleTips       (q.sqt.checked);
       p.sqp                (q.sqp.checked);
       p.snippetSuggestions (q.ss.checked);
+      p.doubleClickToEdit  (q.dce.checked);
     },
     validate() {
       const isInt = (x, minX) => +x === (+x | 0) && +x >= minX;

--- a/src/se.js
+++ b/src/se.js
@@ -92,8 +92,10 @@
         if (e.event.timestamp - mouseTS < 400 && mouseL === l && mouseC === c) {
           e.event.preventDefault();
           e.event.stopPropagation();
-          se.ED(me);
-          me.setPosition(p);
+          if (D.prf.doubleClickToEdit()) {
+            se.ED(me);
+            me.setPosition(p);
+          }
         }
         mouseL = l; mouseC = c; mouseTS = e.event.timestamp;
       }

--- a/src/se.js
+++ b/src/se.js
@@ -93,6 +93,7 @@
           e.event.preventDefault();
           e.event.stopPropagation();
           se.ED(me);
+          me.setPosition(p);
         }
         mouseL = l; mouseC = c; mouseTS = e.event.timestamp;
       }


### PR DESCRIPTION
There's no way to prevent the default behaviour of monaco to select a word when double-clicking, so undo this by setting the cursor explicitly.