### PR TITLE
Syntax and prefix completion for new primitives on classic edition

### DIFF
--- a/src/ac.js
+++ b/src/ac.js
@@ -49,9 +49,10 @@
         o.changes.forEach((oc) => {
           const l1 = oc.range.startLineNumber;
           const c1 = oc.range.startColumn;
+          const sc = c1 + y.length - 1;
           const ec = c1 + chg.text.length;
           nr.push({ range: new monaco.Range(l1, c1 - 1, l1, ec), text: y });
-          ns.push(new monaco.Selection(l1, c1, l1, c1));
+          ns.push(new monaco.Selection(l1, sc, l1, sc));
         });
         bqCleanUpMe(me);
         setTimeout(() => {

--- a/src/ide.js
+++ b/src/ide.js
@@ -497,6 +497,18 @@ D.IDE = function IDE(opts = {}) {
   ide.handlers = { // for RIDE protocol messages
     Identify(x) {
       D.remoteIdentification = x;
+      D.isClassic = x.arch[0] === 'C';
+      if (D.isClassic) {
+        Object.keys(D.bq).forEach((k) => {
+          const sysfn = `u${D.bq[k].codePointAt(0).toString(16)}`;
+          if (D.syntax.sysfns_classic.includes(sysfn)) D.bq[k] = `⎕${sysfn}`;
+        });
+        D.bqbqc.forEach((p) => {
+          const sysfn = `u${p.text.codePointAt(0).toString(16)}`;
+          if (D.syntax.sysfns_classic.includes(sysfn)) p.text = `⎕${sysfn}`;
+        });
+      }
+      
       D.InitHelp(x.version);
       ide.updTitle();
       ide.connected = 1;

--- a/src/ide.js
+++ b/src/ide.js
@@ -516,6 +516,7 @@ D.IDE = function IDE(opts = {}) {
       clearTimeout(D.tmr);
       delete D.tmr;
     },
+    InvalidSyntax() { $.err('Invalid syntax.', 'Interpreter error'); },
     Disconnect(x) {
       const m = x.message.toLowerCase(); ide.die();
       if (m === 'dyalog session has ended') {

--- a/src/mon_apl.js
+++ b/src/mon_apl.js
@@ -376,8 +376,9 @@
               [m] = sm.slice(1).match(RegExp(`^${name}`)) || [];
               const ml = (m || '').toLowerCase();
               if (!m) tkn = 'predefined.sysfn';
-              else if (h.vars && h.vars.indexOf(`⎕${ml}`) >= 0) tkn = 'predefined.sysfn.local';
-              else if (D.syntax.sysfns.indexOf(ml) >= 0) tkn = 'predefined.sysfn';
+              else if (h.vars && h.vars.includes(`⎕${ml}`)) tkn = 'predefined.sysfn.local';
+              else if (D.syntax.sysfns.includes(ml)) tkn = 'predefined.sysfn';
+              else if (D.isClassic && D.syntax.sysfns_classic.includes(ml)) tkn = 'predefined.sysfn';
               else tkn = 'invalid.sysfn';
 
               addToken(offset, tkn); offset += 1 + ml.length; break;

--- a/src/syntax_info.js
+++ b/src/syntax_info.js
@@ -4,6 +4,7 @@
         sysfns: ' a á af ai an arbin arbout arg at av avu base c class clear cmd cr cs csv ct cy d dct df div dl dm dmx dq dr dt ea ec ed em en env es et ex exception export fappend favail fc fchk fcopy fcreate fdrop ferase fhist fhold fix flib fmt fnames fnums fprops fr frdac frdci fread frename freplace fresize fsize fstac fstie ftie funtie fx inp instances io json kl l lc load lock lx map mkdir ml monitor na nappend nc ncopy ncreate ndelete nerase new nexists nget ninfo nl nlock nmove nnames nnums nparts nput nq nr nread nrename nreplace nresize ns nsi nsize ntie null nuntie nxlate off opt or path pfkey pp pr profile ps pt pw r refs rl rsi rtl s save sd se sh shadow si signal size sm sr src stack state stop svc sve svo svq svr svs syl tc tcnums tf tget this tid tkill tname tnums tpool tput trace trap treq ts tsync tz ucs ul using vfi vr wa wc wg wn ws wsid wx x xml xsi xt'.split(' '),
         // However, some of these are not present in the object returned by the ReplyGetSyntaxInformation message:
         //      af arg ea ec env es et fc inp l pr ps pt sve syl tf tz ul x                            
+        sysfns_classic: 'u2286 u2338 u233A u2360 u2364 u2365 u2378'.split(' '),
         
         scmd: ('classes clear cmd continue copy cs drop ed erase events fns holds intro lib load methods ns objects obs off ops pcopy props reset save sh sic si sinl tid vars wsid xload').split(' '),
         


### PR DESCRIPTION
Correct syntax rules for classic edition.
Replace prefix completion of new primitives with corresponding system function.