### PR TITLE
Don't install app menu on floating windows

### DIFF
--- a/src/ide.js
+++ b/src/ide.js
@@ -392,6 +392,7 @@ D.IDE = function IDE(opts = {}) {
   updTopBtm();
   $(window).resize(updTopBtm);
   const updMenu = () => {
+    if (D.ide.floating) return;
     try {
       D.installMenu(D.parseMenuDSL(D.prf.menu()));
     } catch (e) {


### PR DESCRIPTION
The application menu should only be updated from the main window. This fixes issue where some menu commands stop working after menu is refreshed/modified dynamically.