### PR TITLE
':' is now considered a separator in ReplyGetLanguageBar

### DIFF
--- a/src/ide.js
+++ b/src/ide.js
@@ -582,7 +582,7 @@ D.IDE = function IDE(opts = {}) {
       const { entries } = x;
       D.lb.order = entries.map((k) => k.avchar || ' ').join('');
       entries.forEach((k) => {
-        nameSep = k.name.split(':',2);
+        const nameSep = k.name.split(':',2);
         if (k.avchar) {
           D.lb.tips[k.avchar] = [
             `${nameSep[1]} (${k.avchar})`,

--- a/src/ide.js
+++ b/src/ide.js
@@ -582,12 +582,13 @@ D.IDE = function IDE(opts = {}) {
       const { entries } = x;
       D.lb.order = entries.map((k) => k.avchar || ' ').join('');
       entries.forEach((k) => {
+        nameSep = k.name.split(':',2);
         if (k.avchar) {
           D.lb.tips[k.avchar] = [
-            `${k.name.slice(5)} (${k.avchar})`,
+            `${nameSep[1]} (${k.avchar})`,
             k.helptext.join('\n'),
           ];
-          D.sqglDesc[k.avchar] = `${k.name.slice(5)} (${k.avchar})`;
+          D.sqglDesc[k.avchar] = `${nameSep[1]} (${k.avchar})`;
         }
       });
       ide.lbarRecreate();


### PR DESCRIPTION
The Language bar now displays the full name of a primitive when running Dyalog 18.2. Ex. before: 'eft Arrow' is now 'Left Arrow'.