### PR TITLE
Get values only for visible items in WSE

### DIFF
--- a/src/bonsai.js
+++ b/src/bonsai.js
@@ -127,7 +127,6 @@
           depth: 0,
           path: '',
           text: '',
-          // value: [''],
           expanded: 1,
         }
       };
@@ -183,11 +182,13 @@
     }
 
     requestValueTip(node) {
-      if (node.id < 2) return;
+      if (node.valueRequested || node.id < 2) return;
       const bt = this;
+      node.valueRequested = 1;
       bt.pendingCalls += 1;
       bt.valueTipCb(node, (x) => {
         node.value = x.tip;
+        delete node.valueRequested;
         bt.pendingCalls -= 1;
         !bt.pendingCalls && bt.replaceTree();
       });

--- a/src/wse.js
+++ b/src/wse.js
@@ -50,7 +50,6 @@
         // x.classes uses constants from http://help.dyalog.com/17.0/Content/Language/System%20Functions/nc.htm
         id: c || `leaf_${x.nodeId}_${i}`,
         text: x.names[i],
-        value: [''],
         expandable: !!c,
         icon: `${Math.abs(x.classes[i])}`.replace('.', '_'),
       })));


### PR DESCRIPTION
Fetching values for all items in the Workspace Explorer is slow when the tree is very large. This change limits the fetching to the nodes currently visible in the window.