### PR TITLE
Double-click selects word if not valid apl name

### DIFF
--- a/src/ed.js
+++ b/src/ed.js
@@ -106,8 +106,7 @@
       } else if (t.type === mt.CONTENT_TEXT
         || (ed.isReadOnly && t.type === mt.CONTENT_EMPTY)) {
         if (e.event.timestamp - mouseTS < 400 && mouseL === p.lineNumber && mouseC === p.column) {
-          e.event.preventDefault(); e.event.stopPropagation();
-          if (D.prf.doubleClickToEdit()) {
+          if (D.prf.doubleClickToEdit() && D.ide.cword(me, p)) {
             ed.ED(me);
             me.setPosition(p);
           }
@@ -361,15 +360,6 @@
     die() { this.setRO(1); this.ide.connected = 0; },
     getDocument() { return this.dom.ownerDocument; },
     refresh() { },
-    cword() { // apl identifier under cursor
-      const { me } = this;
-      const p = me.getPosition();
-      const c = p.column - 1;
-      const s = me.getModel().getLineContent(p.lineNumber);
-      const [loc] = RegExp(`⎕?${D.syntax.name}?$`).exec(s.slice(0, c)); // match left of cursor
-      const [roc] = RegExp(`^⎕?[${D.syntax.letter}\\d]*`).exec(s.slice(c)); // match right of cursor
-      return RegExp(`^(${D.syntax.sysvar}|${D.syntax.name})?\\b`, 'i').exec(loc + roc)[0];
-    },
     autoCloseBrackets(x) { this.me.updateOptions({ autoClosingBrackets: x }); },
     indent(x) { this.me.updateOptions({ autoIndent: x >= 0 }); },
     fold(x) { this.me.updateOptions({ folding: this.isCode && !!x }); },
@@ -497,7 +487,7 @@
       D.send('SaveChanges', { win: ed.id, text: v.split(me.getModel().getEOL()), stop });
     },
     TL(me) { // toggle localisation
-      const name = this.cword();
+      const name = D.ide.cword(me);
       const model = me.getModel();
       const getState = (l) => model._tokenization._tokenizationStateStore._beginState[l];
       if (!name) return;
@@ -610,7 +600,7 @@
     VAL(me) {
       const a = me.getSelections();
       if (a.length !== 1 || monaco.Selection.spansMultipleLines(a[0])) return;
-      const s = a[0].isEmpty() ? this.cword() : me.getModel().getValueInRange(a[0]);
+      const s = a[0].isEmpty() ? D.ide.cword(me) : me.getModel().getValueInRange(a[0]);
       this.ide.exec([`      ${s}`], 0);
     },
     addJump() {

--- a/src/ide.js
+++ b/src/ide.js
@@ -864,6 +864,14 @@ D.IDE.prototype = {
   setCursorPosition(p, lc) {
     I.sb_cp.innerText = `Pos: ${p.lineNumber - 1}/${lc},${p.column - 1}`;
   },
+  cword(me, position) { // apl identifier under cursor
+    const p = position || me.getPosition();
+    const c = p.column - 1;
+    const s = me.getModel().getLineContent(p.lineNumber);
+    const [loc] = RegExp(`⎕?${D.syntax.name}?$`).exec(s.slice(0, c)); // match left of cursor
+    const [roc] = RegExp(`^⎕?[${D.syntax.letter}\\d]*`).exec(s.slice(c)); // match right of cursor
+    return (RegExp(`^(${D.syntax.sysvar}|${D.syntax.name})?\\b`, 'i').exec(loc + roc) || [''])[0];
+  },
   die() { // don't really, just pretend
     const ide = this;
     if (ide.dead) return;

--- a/src/se.js
+++ b/src/se.js
@@ -92,9 +92,7 @@
         const l = p.lineNumber;
         const c = p.column;
         if (e.event.timestamp - mouseTS < 400 && mouseL === l && mouseC === c) {
-          e.event.preventDefault();
-          e.event.stopPropagation();
-          if (D.prf.doubleClickToEdit()) {
+          if (D.prf.doubleClickToEdit() && D.ide.cword(me, p)) {
             se.ED(me);
             me.setPosition(p);
           }


### PR DESCRIPTION
Irrespective of configuration, double-clicking on something other than a valid APL name now selects the word.