### PR TITLE
Fix broken hlp.js help paths

### DIFF
--- a/src/hlp.js
+++ b/src/hlp.js
@@ -61,7 +61,7 @@
       819: 'Case Convert',
       900: 'Called Monadically',
       950: 'Loaded Libraries',
-      1111: 'Number of Threads',
+      1111: 'Number Of Threads',
       1112: 'Parallel Execution Threshold',
       1159: 'Update Function Timestamp',
       1500: 'Hash Array',
@@ -81,8 +81,8 @@
       2101: 'Close .NET AppDomain', // W
       2400: 'Set Workspace Save Options',
       2401: 'Expose Root Properties',
-      2501: 'Discard thread on exit', // W
-      2502: 'Discard parked threads', // W
+      2501: 'Discard Thread on Exit', // W
+      2502: 'Discard Parked Threads', // W
       2503: 'Mark Thread as Uninterruptible',
       2520: 'Use Separate Thread For .NET',
       2704: 'Continue Autosave',

--- a/src/hlp.js
+++ b/src/hlp.js
@@ -25,7 +25,7 @@
     for (let i = 0; i < a.length; i++) h[`)${a[i]}`] = u + a[i] + q;
 
     u = `${p}Language/System Functions/`;
-    h.SYSFNS = `${u}System Functions Categorised${q}`;
+    h.SYSFNS = `${u}Summary Tables/System Functions Categorised${q}`;
     h['⍞'] = `${u}Character Input Output${q}`;
     h['⎕'] = `${u}Evaluated Input Output${q}`;
     h['⎕á'] = `${u}Underscored Alphabetic Characters${q}`;
@@ -53,8 +53,8 @@
       181: 'Unsqueezed Type',
       200: 'Syntax Colouring',
       201: 'Syntax Colour Tokens',
-      219: 'Compress/Decompress Vector of Short Integers',
-      220: 'Serialise/Deserialise Array',
+      219: 'Compress Vector of Short Integers',
+      220: 'Serialise Array',
       400: 'Compiler Control',
       600: 'Trap Control',
       739: 'Temporary Directory',
@@ -63,7 +63,7 @@
       950: 'Loaded Libraries',
       1111: 'Number of Threads',
       1112: 'Parallel Execution Threshold',
-      1159: 'Update Function Time and User Stamp',
+      1159: 'Update Function Timestamp',
       1500: 'Hash Array',
       2000: 'Memory Manager Statistics',
       2002: 'Specify Workspace Available',
@@ -72,7 +72,7 @@
       2014: 'Remove Data Binding', // W
       2015: 'Create Data Binding Source', // W
       2016: 'Create .NET Delegate', // W
-      2017: 'Identify .NET Type', // W
+      2017: 'Identify NET Type', // W
       2022: 'Flush Session Caption', // W
       2023: 'Close All Windows',
       2035: 'Set Dyalog Pixel Type', // W


### PR DESCRIPTION
`SYSFNS` and a couple I-beams have broken links.

(Actually help is currently broken for all I-beams on RIDE 4.3.3463. This has already been fixed by #630 but I guess I have to wait until RIDE 4.4 it out)