### PR TITLE
Update cursor visibility when editing traced fn

### DIFF
--- a/src/ed.js
+++ b/src/ed.js
@@ -356,7 +356,7 @@
     },
     prompt(x) {
       this.setRO(this.tc || !x);
-      this.tc && this.setPendent(!x);
+      this.setPendent(!x);
     },
     die() { this.setRO(1); this.ide.connected = 0; },
     getDocument() { return this.dom.ownerDocument; },


### PR DESCRIPTION
When switching to edit mode in a tracer, the cursor should be visible.