### PR TITLE
Tab buttons for editor windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,6 +580,7 @@
       <p><label class=cb_label><input id=code_sqp  type=checkbox>Show <u>q</u>uit prompt</label></p>
       <p><label class=cb_label><input id=code_set  type=checkbox>Show toolbar in editor/trace windows</label></p>
       <p><label class=cb_label><input id=code_coq  type=checkbox>Connect on quit</label></p>
+      <p><label class=cb_label><input id=code_fit  type=checkbox>Include filename in editor title</label></p>
     </div>
 
     <!--Colours-->

--- a/src/ed.js
+++ b/src/ed.js
@@ -261,7 +261,7 @@
       ed.name = ee.name;
       // Check if a filename for a source file is provided.
       // Make sure it isn't duplicated in the existing name.
-      if (ee.filename && (ed.name.indexOf(ee.filename) === -1)) {
+      if (ee.filename && (ed.name.indexOf(ee.filename) === -1) && D.prf.filenameInTitle()) {
         ed.name = ed.name.concat(' in ', ee.filename);
       }
       if (ed.container) {

--- a/src/ed.js
+++ b/src/ed.js
@@ -264,7 +264,10 @@
       if (ee.filename && (ed.name.indexOf(ee.filename) === -1)) {
         ed.name = ed.name.concat(' in ', ee.filename);
       }
-      ed.container && ed.container.setTitle(ed.name);
+      if (ed.container) {
+        ed.container.setTitle(ed.name);
+        ed.container.tab.header.parent.trigger('resize');
+      }
       D.ide.floating && $('title', ed.dom.ownerDocument).text(`${ed.name} - ${ed.ide.caption}`);
       model.winid = ed.id;
       model.setValue(ed.oText = ee.text.join(model.getEOL()));

--- a/src/prf.js
+++ b/src/prf.js
@@ -19,6 +19,7 @@ D.prf = {};
   ['confirmations',      {}],//saved responses to TaskDialog questions
   ['connectOnQuit',      0], // open connection page when active session ends
   ['doubleClickToEdit',  1], // whether double clicking a function name in session or editor opens an editor on that function
+  ['filenameInTitle',    1], // include filename in editor title
   ['floating',           0], //floating editor and tracer windows
   ['floatSingle',        1], //create single floating edit window
   ['fold',               1], //code folding

--- a/src/prf_code.js
+++ b/src/prf_code.js
@@ -55,6 +55,7 @@
       q.bc.checked = !!p.blockCursor();
       q.cb.value = p.cursorBlinking();
       q.coq.checked = !!p.connectOnQuit();
+      q.fit.checked = !!p.filenameInTitle();
       q.rlh.value = p.renderLineHighlight();
       q.apw.checked = !!p.autoPW();
       q.ph.checked = !!p.persistentHistory();
@@ -89,6 +90,7 @@
       p.autoPW             (q.apw.checked);
       p.autocompletionDelay(q.acd.value);
       p.connectOnQuit      (q.coq.checked);
+      p.filenameInTitle    (q.fit.checked);
       p.renderLineHighlight(q.rlh.value);
       p.persistentHistory  (q.ph.checked);
       p.persistentHistorySize(q.phs.value);


### PR DESCRIPTION
* In some circumstances the tab button for a newly opened editor window was not shown.
* A configuration option added to General tab to opt out of seeing the filename in the editor title.