### PR TITLE
Update PW on resize of session, fix #813

### DIFF
--- a/src/cn.js
+++ b/src/cn.js
@@ -1015,7 +1015,7 @@
   module.exports = () => {
     D.send = (x, y) => {
       if (D.ide && !D.ide.promptType
-        && !/Interrupt$|TreeList|Reply|FormatCode|GetAutocomplete|SaveChanges|CloseWindow|Exit/.test(x)) return;
+        && !/Interrupt$|TreeList|Reply|FormatCode|GetAutocomplete|SaveChanges|CloseWindow|Exit|SetPW/.test(x)) return;
       sendEach([JSON.stringify([x, y])]);
     };
     const a = rq('@electron/remote').process.argv;

--- a/src/ide.js
+++ b/src/ide.js
@@ -392,7 +392,7 @@ D.IDE = function IDE(opts = {}) {
     ide.dom.style.top = `${(D.prf.lbar() ? I.lb.offsetHeight : 0) + (D.el ? 0 : 23)}px`;
     ide.dom.style.bottom = `${I.sb.offsetHeight}px`;
     gl.updateSize(ide.dom.clientWidth, ide.dom.clientHeight);
-    ide.updPW(-1);
+    ide.updPW();
   });
   I.lb.hidden = !D.prf.lbar();
   I.sb.hidden = !D.prf.sbar();
@@ -531,7 +531,7 @@ D.IDE = function IDE(opts = {}) {
       D.InitHelp(x.version);
       ide.updTitle();
       ide.connected = 1;
-      ide.updPW(-1);
+      ide.updPW();
       clearTimeout(D.tmr);
       delete D.tmr;
     },

--- a/src/km.js
+++ b/src/km.js
@@ -265,9 +265,9 @@
       w.container.parent.toggleMaximise();
       setTimeout(() => { me && me.focus(); }, 100);
     },
-    ZMI() { D.prf.zoom(Math.min(12, D.prf.zoom() + 1)); D.ide.updPW(); },
-    ZMO() { D.prf.zoom(Math.max(-10, D.prf.zoom() - 1)); D.ide.updPW(); },
-    ZMR() { D.prf.zoom(0); D.ide.updPW(); },
+    ZMI() { D.prf.zoom(Math.min(12, D.prf.zoom() + 1)); },
+    ZMO() { D.prf.zoom(Math.max(-10, D.prf.zoom() - 1)); },
+    ZMR() { D.prf.zoom(0); },
 
   });
 

--- a/src/se.js
+++ b/src/se.js
@@ -369,15 +369,13 @@
       }
     },
     updPW(force) {
-      // force: -1 => delayed update (once gl size established)
-      //         1 => immediate update
+      // force:emit a SetPW message even if the width hasn't changed
       const se = this;
       if (!D.prf.autoPW()) return;
-      if (force === -1) { se.setPW = !0; return; }
-      if (!se.setPW && force !== 1) return;
       const pw = Math.max(42, se.me.getLayoutInfo().viewportColumn);
-      if (pw !== se.pw && se.ide.connected) D.send('SetPW', { pw: se.pw = pw });
-      se.setPW = !1;
+      if ((force || pw !== se.pw) && se.ide.connected) {
+        D.send('SetPW', { pw: se.pw = pw });
+      }
     },
     scrollCursorIntoView() {
       const { me } = this;


### PR DESCRIPTION
When Auto PW enabled, PW should be updated when width of session is changed due to other windows being opened.