### PR TITLE
Show ValueTip in floating windows and for ⍺ ⍵

### DIFF
--- a/src/ed.js
+++ b/src/ed.js
@@ -478,7 +478,7 @@
         const { vt } = model;
         const l = vt.position.lineNumber;
         const value = '```'
-        + `${x.class === 2 ? 'plaintext' : 'apl'}\n`
+        + `${x.class === 2 || x.class === 14 ? 'plaintext' : 'apl'}\n`
         + `${x.tip.join('\n')}\n`
         + '```';
         vt.complete({

--- a/src/ide.js
+++ b/src/ide.js
@@ -859,9 +859,13 @@ D.IDE = function IDE(opts = {}) {
 D.IDE.prototype = {
   getValueTip(source, id, request) {
     const ide = this;
-    request.token = ide.valueTipToken++;
-    ide.valueTipRequests[request.token] = { id, source };
-    D.send('GetValueTip', request);
+    if (this.floating) {
+      this.ipc.emit('getValueTip', [source, id, request]);
+    } else {
+      request.token = ide.valueTipToken++;
+      ide.valueTipRequests[request.token] = { id, source };
+      D.send('GetValueTip', request);
+    }
   },
   setConnInfo(x, y, z) {
     const ide = this;

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -204,6 +204,7 @@
           delete D.pendingEdit;
         }
       });
+      srv.on('getValueTip', (data) => D.ide.getValueTip(...data));
       srv.on('prf', ([k, x]) => { D.prf[k](x); });
       srv.on('switchWin', data => D.ide.switchWin(data));
       srv.on('updPW', data => D.ide.updPW(data));

--- a/src/se.js
+++ b/src/se.js
@@ -543,7 +543,7 @@
         const { vt } = model;
         const l = vt.position.lineNumber;
         const value = '```'
-          + `${x.class === 2 ? 'plaintext' : 'apl'}\n`
+          + `${x.class === 2 || x.class === 14 ? 'plaintext' : 'apl'}\n`
           + `${x.tip.join('\n')}\n`
           + '```';
         vt.complete({


### PR DESCRIPTION
Value tip in floating windows is fixed and the styling of tips for ⍺ ⍵ is changed to plain text.