### PR TITLE
Adds a GitHub workflow to generate zip files only of the Windows distribution

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -46,7 +46,7 @@ jobs:
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
           zip -r -9 ../../../ride.zip *
       - name: Create Release and Upload Assets
-        uses: lstefano71/github-release@2.0
+        uses: lstefano71/github-release@2.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ steps.date.outputs.result }}

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # - name: Get current date
+      #   id: date
+      #   run: echo "date=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
@@ -17,51 +20,50 @@ jobs:
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y wine64
       - run: node mk w
-      - run: ls _ -R
-      - run: cat _/version.js
-      - run: cat _/version
-      # - name: Prepare release archive unicode
-      #   run: >
-      #     zip -r -9 dfs_unicode.zip 
-      #     *.dyalog 
-      #     *.dyapp 
-      #     Core 
-      #     DFSConfig 
-      #     DFSMonitor 
-      #     Documentation 
-      #     ErrorPages 
-      #     Extensions 
-      #     PlugIns 
-      #     Utils 
-      #     *.dws
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     # tag_name: ${{ github.ref }}
-      #     tag_name: v${{ steps.date.outputs.date }}
-      #     release_name: Release ${{steps.date.outputs.date }} (${{ github.ref }})
-      #     draft: false
-      #     prerelease: false
-      # - name: Upload Unicode
-      #   id: upload-unicode
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-      #     asset_path: ./dfs_unicode.zip
-      #     asset_name: dfs-${{ steps.date.outputs.date }}-unicode.zip
-      #     asset_content_type: application/zip
-      # - name: Upload Classic
-      #   id: upload-classic
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-      #     asset_path: ./dfs_classic.zip
-      #     asset_name: dfs-${{ steps.date.outputs.date }}-classic.zip
-      #     asset_content_type: application/zip
+      - run: |
+          echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
+          cat ./package.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - run: |
+          echo 'VERSION_JSON<<EOF' >> $GITHUB_ENV
+          cat ./_/version.js >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - run: npm install strftime
+      - uses: actions/github-script@v6
+        id: date
+        env:
+          RAW_DATE: ${{ fromJson(env.VERSION_JSON).versionInfo.date }}
+        with:
+          result-encoding: string
+          script: |
+            const strftime = require('strftime');
+            const {RAW_DATE} = process.env; // "2023-05-02 12:01:02 +0200"
+            const date = new Date(RAW_DATE);
+            const fmt = strtime('',date);
+            return '%Y%m$d-%H%M%S';
+      - name: Prepare zip
+        run: |
+          cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).prodyctName }}-win32-ia32
+          zip -r -9 ../../../ride.zip *
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVT_DATE: $${{ steps.date.outputs.result }}
+        with:
+          tag_name: v${{ EVT_DATE }}
+          release_name: Release ${{ EVT_DATE }} (${{ github.ref }})
+          draft: false
+          prerelease: false
+      - name: Upload Unicode
+        id: upload-unicode
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVT_DATE: $${{ steps.date.outputs.result }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./ride.zip
+          asset_name: ride-${{ EVT_DATE }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Prepare zip
         run: |
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
-          mv {{ fromJson(env.PACKAGE_JSON).productName }}.exe Ride.exe
+          mv ${{ fromJson(env.PACKAGE_JSON).productName }}.exe Ride.exe
           zip -r -9 ../../../ride.zip *
       - name: Create Release and Upload Assets
         uses: lstefano71/github-release@2.0.4

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -33,29 +33,26 @@ jobs:
             const strftime = require('strftime');
             const {stdout} = await exec.getExecOutput('git show -s HEAD --pretty=format:%ci'); // "2023-05-02 12:01:02 +0200"
             const date = new Date(stdout);
-            const fmt = strftime('',date);
-            return '%Y%m$d-%H%M%S';
+            const fmt = strftime('%Y%m$d-%H%M%S',date);
+            return fmt;
       - name: Prepare zip
         run: |
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
           zip -r -9 ../../../ride.zip *
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.date.outputs.result }}
-          release_name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
+          name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
+          generate_release_notes: true
           draft: false
           prerelease: false
-      - name: Upload Unicode
-        id: upload-unicode
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload assets
+        uses: KotwOSS/pipe-to-release@2
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./ride.zip
-          asset_name: ride-${{ steps.date.outputs.result }}.zip
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: v${{ steps.date.outputs.result }}
+          filemap: |
+            ./ride.zip>ride-${{ steps.date.outputs.result }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -40,15 +40,11 @@ jobs:
             const date = new Date(stdout);
             const fmt = strftime('%Y%m%d-%H%M%S',date);
             return fmt;
-      # rename Exe
-      - name: Rename exe
-        run: |
-          cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
-          mv {{ fromJson(env.PACKAGE_JSON).productName }}.exe Ride.exe
-      # zip client
+      # rename exe and zip client
       - name: Prepare zip
         run: |
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
+          mv {{ fromJson(env.PACKAGE_JSON).productName }}.exe Ride.exe
           zip -r -9 ../../../ride.zip *
       - name: Create Release and Upload Assets
         uses: lstefano71/github-release@2.0.4

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -39,20 +39,15 @@ jobs:
         run: |
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
           zip -r -9 ../../../ride.zip *
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ steps.date.outputs.result }}
-          name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-      - name: Upload assets
-        uses: KotwOSS/pipe-to-release@2
+      - name: Create Release and Upload Assets
+        uses: KotwOSS/pipe-to-release@2.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ steps.date.outputs.result }}
+          name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
           filemap: |
             ./ride.zip>ride-${{ steps.date.outputs.result }}.zip
-          asset_content_type: application/zip
+          draft: false
+          prerelease: false
+
+

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,0 +1,65 @@
+name: Build and ZIP for Windows
+
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm install
+      - run: sudo apt-get update -y
+      - run: sudo apt-get install -y wine64
+      - run: node mk w
+      - run: ls _ 
+      # - name: Prepare release archive unicode
+      #   run: >
+      #     zip -r -9 dfs_unicode.zip 
+      #     *.dyalog 
+      #     *.dyapp 
+      #     Core 
+      #     DFSConfig 
+      #     DFSMonitor 
+      #     Documentation 
+      #     ErrorPages 
+      #     Extensions 
+      #     PlugIns 
+      #     Utils 
+      #     *.dws
+      # - name: Create Release
+      #   id: create_release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     # tag_name: ${{ github.ref }}
+      #     tag_name: v${{ steps.date.outputs.date }}
+      #     release_name: Release ${{steps.date.outputs.date }} (${{ github.ref }})
+      #     draft: false
+      #     prerelease: false
+      # - name: Upload Unicode
+      #   id: upload-unicode
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+      #     asset_path: ./dfs_unicode.zip
+      #     asset_name: dfs-${{ steps.date.outputs.date }}-unicode.zip
+      #     asset_content_type: application/zip
+      # - name: Upload Classic
+      #   id: upload-classic
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+      #     asset_path: ./dfs_classic.zip
+      #     asset_name: dfs-${{ steps.date.outputs.date }}-classic.zip
+      #     asset_content_type: application/zip

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -40,6 +40,11 @@ jobs:
             const date = new Date(stdout);
             const fmt = strftime('%Y%m%d-%H%M%S',date);
             return fmt;
+      # rename Exe
+      - name: Rename exe
+        run: |
+          cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
+          mv {{ fromJson(env.PACKAGE_JSON).productName }}.exe Ride.exe
       # zip client
       - name: Prepare zip
         run: |

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -17,7 +17,9 @@ jobs:
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y wine64
       - run: node mk w
-      - run: ls _ 
+      - run: ls _ -R
+      - run: cat _/version.js
+      - run: cat _/version
       # - name: Prepare release archive unicode
       #   run: >
       #     zip -r -9 dfs_unicode.zip 

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -33,7 +33,7 @@ jobs:
             const strftime = require('strftime');
             const {stdout} = await exec.getExecOutput('git show -s HEAD --pretty=format:%ci'); // "2023-05-02 12:01:02 +0200"
             const date = new Date(stdout);
-            const fmt = strtime('',date);
+            const fmt = strftime('',date);
             return '%Y%m$d-%H%M%S';
       - name: Prepare zip
         run: |

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -24,26 +24,20 @@ jobs:
           echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
           cat ./package.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-      - run: |
-          echo 'VERSION_JSON<<EOF' >> $GITHUB_ENV
-          cat ./_/version.js >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
       - run: npm install strftime
       - uses: actions/github-script@v6
         id: date
-        env:
-          RAW_DATE: ${{ fromJson(env.VERSION_JSON).versionInfo.date }}
         with:
           result-encoding: string
           script: |
             const strftime = require('strftime');
-            const {RAW_DATE} = process.env; // "2023-05-02 12:01:02 +0200"
-            const date = new Date(RAW_DATE);
+            const {stdout} = await exec.getExecOutput('git show -s HEAD --pretty=format:%ci'); // "2023-05-02 12:01:02 +0200"
+            const date = new Date(stdout);
             const fmt = strtime('',date);
             return '%Y%m$d-%H%M%S';
       - name: Prepare zip
         run: |
-          cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).prodyctName }}-win32-ia32
+          cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
           zip -r -9 ../../../ride.zip *
       - name: Create Release
         id: create_release

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -46,12 +46,13 @@ jobs:
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
           zip -r -9 ../../../ride.zip *
       - name: Create Release and Upload Assets
-        uses: meeDamian/github-release@2.0
+        uses: lstefano71/github-release@2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ steps.date.outputs.result }}
           name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
           files: ride-${{ steps.date.outputs.result }}.zip:./ride.zip
+          gzip: false
           draft: false
           prerelease: false
 

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -50,10 +50,9 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVT_DATE: $${{ steps.date.outputs.result }}
         with:
-          tag_name: v${{ EVT_DATE }}
-          release_name: Release ${{ EVT_DATE }} (${{ github.ref }})
+          tag_name: v${{ steps.date.outputs.result }}
+          release_name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
           draft: false
           prerelease: false
       - name: Upload Unicode
@@ -61,9 +60,8 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EVT_DATE: $${{ steps.date.outputs.result }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./ride.zip
-          asset_name: ride-${{ EVT_DATE }}.zip
+          asset_name: ride-${{ steps.date.outputs.result }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -16,14 +16,19 @@ jobs:
         with:
           node-version: 18
           cache: npm
+      # hydrate node modules
       - run: npm install
+      # install wine64
       - run: sudo apt-get update -y
       - run: sudo apt-get install -y wine64
+      # make the windows client
       - run: node mk w
+      # import package.json
       - run: |
           echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
           cat ./package.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+      # convert date to string usable in file name
       - run: npm install strftime
       - uses: actions/github-script@v6
         id: date
@@ -33,20 +38,20 @@ jobs:
             const strftime = require('strftime');
             const {stdout} = await exec.getExecOutput('git show -s HEAD --pretty=format:%ci'); // "2023-05-02 12:01:02 +0200"
             const date = new Date(stdout);
-            const fmt = strftime('%Y%m$d-%H%M%S',date);
+            const fmt = strftime('%Y%m%d-%H%M%S',date);
             return fmt;
+      # zip client
       - name: Prepare zip
         run: |
           cd _/${{ fromJson(env.PACKAGE_JSON).name }}/${{ fromJson(env.PACKAGE_JSON).productName }}-win32-ia32
           zip -r -9 ../../../ride.zip *
       - name: Create Release and Upload Assets
-        uses: KotwOSS/pipe-to-release@2.0.3
+        uses: meeDamian/github-release@2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: v${{ steps.date.outputs.result }}
+          tag: v${{ steps.date.outputs.result }}
           name: Release ${{ steps.date.outputs.result }} (${{ github.ref }})
-          filemap: |
-            ./ride.zip>ride-${{ steps.date.outputs.result }}.zip
+          files: ride-${{ steps.date.outputs.result }}.zip:./ride.zip
           draft: false
           prerelease: false
 


### PR DESCRIPTION
The zip file is named with a date in the name.
Before zipping, the executable is renamed to a generic ride.exe so that in a system with a shortcut pointing to the file, no renames are needed to update to the latest version. This may not be what is desired and can be discussed. 

This closes https://github.com/lstefano71/ride/issues/1 and it's a home made proposal to implement #453