### PR TITLE
Update dyalog website url in README to point to external source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # RIDE
 
-RIDE is a remote IDE for [Dyalog](www.dyalog.com) APL.
+RIDE is a remote IDE for [Dyalog](https://www.dyalog.com) APL.
 
 ![Screenshot](/screenshot.png?raw=true)
 


### PR DESCRIPTION
Hi, Just a small change to the readme.

The URL redirected to a local URL in the ride repository(https://github.com/Dyalog/ride/blob/master/www.dyalog.com) instead of external https://www.dyalog.com

Thanks