### PR TITLE
Handle missing version.js when developing

### DIFF
--- a/src/pre_init.js
+++ b/src/pre_init.js
@@ -3,6 +3,7 @@ var D = typeof D === "undefined" ? {} : D;
 
 D.commands = {};
 D.keyMap = { dyalog: {}, dyalogDefault: {} };
+D.versionInfo = D.versionInfo || {};
 
 // all elements by id, eg I.lb_tip_text is document.getElementById('lb_tip_text')
 const I = {};


### PR DESCRIPTION
When running a local development session without first building the project RIDE fails to run. This change handles the missing version.js file from the build directory.