### PR TITLE
#1092 Set permissions of O/S-specific directories in /devt/builds/rid…

### DIFF
--- a/CI/publish.sh
+++ b/CI/publish.sh
@@ -47,6 +47,7 @@ for DIR in `ls _/${APP_NAME}`; do
 	echo "DEBUG: \$OSNAME=$OSNAME"
 
   cp -R _/${APP_NAME}/${DIR} $r/$d/${OSNAME}
+  chmod 755 $r/$d/${OSNAME}
 done
 
 echo 'fixing permissions'; chmod +x $r/$d/win32/{*.exe,*.dll}


### PR DESCRIPTION
…e/master
Permissions in /devt/builds/... are such that no one can copy files from O/S-specific directories.  So chmod 755 to allow this.