### PR TITLE
Reviewing content for 4.5, part2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # About This Document
 
-This document introduces the Remote Integrated Development Environment (RIDE). It describes the installation process and the RIDE's user interface (windows, menus, customisation options, keycode/keystroke mappings, etc.).
+This document introduces the Remote Integrated Development Environment (RIDE). It describes the installation process and RIDE's user interface (windows, menus, customisation options, keycode/keystroke mappings, etc.).
 
 RIDE can be extensively customised; this document assumes that the default configuration is in use.
 

--- a/docs/input_windows.md
+++ b/docs/input_windows.md
@@ -1,254 +1,50 @@
-# Input Windows
+# Edit and Trace Windows
 
-Instead of just a single **Session** window, the Dyalog Development Environment can comprise multiple windows:
+## Edit
 
-- **Session** window – created when a Dyalog Session is started through the RIDE and always present while the Session is live. There is only one [Session window](session_window_input.md).
-- **Edit** windows – created and destroyed dynamically as required. There can be multiple [Edit windows](edit_window.md) (one for each APL object).
-- **Trace** window – created and destroyed dynamically as required. There is only one [Trace window](trace_window.md).
+An **Edit** window can be opened in any of the following ways:
 
-When multiple windows are open, the window that has the focus is referred to as the *active window*.
+- Enter `)ED <item name>` in the interactive session
+- Enter `⎕ED '<item name>'` in the interactive session
+- Press <kbd>Shift</kbd>+<kbd>Enter</kbd> (can be configured via `Edit > Preferences> Shortcuts > ED`) while the text cursor is on or adjacent to any item name
+- Double-click on or adjacent to an item name (can be toggled via `Edit > Preferences > Trace/Edit > Double click to edit`)
 
-## Session Window
+If the object name does not already exist, then it becomes a function or operator. Different types can be explicitly specified using the `)ED` or `⎕ED` options – see `)ED` or `⎕ED` in the [Dyalog APL Language Reference Guide](https://docs.dyalog.com/latest/Dyalog%20APL%20Language%20Reference%20Guide.pdf).
 
-The **Session** window contains:
+A **Trace** window can be temporarily changed into an **Edit** window by pressing <kbd>Shift</kbd>+<kbd>Enter</kbd> or clicking <img src="../img/screenshots/i_intext_editname.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> while the text cursor is not on or adjacent to any name.
 
-- the *input line* – the last line entered in the **Session** window; this is (usually) the line into which you type an expression to be evaluated.
-- a *gutter* – the left-hand side of the window is a gutter that can include input/output information. Specifically: a small red circle in the gutter is present on every line that has been modified since last pressing Enter. This includes old lines that have been modified as well as new lines. These indicators show which lines will be executed when you subsequently hit Enter, at which point the indicator is removed.a left bracket indicates "groups" of default output (to distinguish it from `⎕` or `⍞` output).
-- a small *red circle* in the gutter is present on every line that has been modified since last pressing <kbd>Enter</kbd>. This includes old lines that have been modified as well as new lines. These indicators show which lines will be executed when you subsequently hit <kbd>Enter</kbd>, at which point the indicator is removed.
-- a *left bracket* indicates "groups" of default output (to distinguish it from `⎕` or `⍞` output).
-- the *Session log* – a history of previously-entered expressions and the results they produced.
+To save your changes and exit the **Edit** window, press <kbd>Esc</kbd> (can be configured via `Edit > Preferences> Shortcuts > EP`) or click <img src="../img/screenshots/i_intext_quit.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 14px;" />.
 
-If a log file is being used, then the Session log is loaded into memory when a Dyalog Session is started. When the Dyalog Session is closed, the Session log is written to the log file, replacing its previous contents.
+To exit the **Edit** window without saving, press <kbd>Shift</kbd>+<kbd>Esc</kbd> (can be configured via `Edit > Preferences> Shortcuts > QT`).
 
-## Edit Window
+## Trace
+
+The **Trace** window aids debugging by enabling you to step through your code line by line, display variables in **Edit** windows and watch them change as the execution progresses.
+
+A **Trace** window can be opened from the **Session** window by pressing <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (can be configured via `Edit > Preferences > Shortcuts > TC`) after typing an expression.
 
 !!!note
-    This section applies to the RIDE's built-in editor. A different editor can be specified by setting the `RIDE_EDITOR` configuration parameter to the fully-qualified path of the desired editor's executable file.
+    By default, Dyalog is also configured to initiate an automatic trace whenever an error occurs, that is, the **Trace** window opens and becomes the active window and the line that caused the execution to suspend is selected. This is controlled by the interpreter configuration parameter `TRACE_ON_ERROR`. For information on configuration parameters, see the Dyalog Installation and Configuration Guide for your operating system:
 
-The **Edit** window is used to define new objects as well as view/amend existing objects.
+    - [macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)
+    - [Microsoft Windows Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20Microsoft%20Windows%20Installation%20and%20Configuration%20Guide.pdf)
+    - [UNIX Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20UNIX%20Installation%20and%20Configuration%20Guide.pdf)
 
-An **Edit** window can be opened from the Session window in any of the following ways:
+To resume execution, press the |> button (can be given a keyboard shortcut via `Edit > Preferences> Shortcuts > RM`).
 
-- Enter `)ED <object name>`
-- Enter `⎕ED '<object name>'`
-- Enter `<object name>` [<ED>](keyboard_shortcuts_and_command_codes.md)
-- Double-click on/after `<object name>`
+To resume execution until the current function returns, press the |¯\\. button (can be given a keyboard shortcut via `Edit > Preferences> Shortcuts > BH`).
 
-If the object name does not already exist, then it is assumed to of function/operator type. Different types can be explicitly specified using the `)ED` or `⎕ED` options – see `)ED` or `⎕ED` in the [Dyalog APL Language Reference Guide](https://docs.dyalog.com/latest/Dyalog%20APL%20Language%20Reference%20Guide.pdf).
+To cut back the stack one level, press <kbd>Esc</kbd> (can be configured via Edit > Preferences> Shortcuts > `EP`) or click <img src="../img/screenshots/i_intext_quit.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 14px;" />.
 
-An Edit window can be opened from the Trace window by entering the Edit command (`<ED>`), double‑clicking the cursor or clicking the <img src="../img/screenshots/i_intext_editname.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> button in the [toolbar](toolbar_tracewindow.md). The position of the cursor when this is done determines the name of the object that the Edit window is for:
+## Navigating the Windows
 
-- If the cursor is on or immediately after `<object name>`, then the Edit window opens on that name.
-- If the cursor is anywhere else, then the **Edit** window opens for the most recently-referenced function on the stack. This is a naked edit.
+New Edit and Trace windows can be floating rather than docked by selecting the **Floating windows** checkbox in the [Windows tab](customising_your_session.md/#windows-tab) of the **Preferences** dialog box.
 
-An Edit window can be opened from another Edit window in any of the following ways:
+Docked or not, the **Session**, **Edit** and **Trace** windows form a closed loop for the purpose of navigation:
+- to make the next window in this loop the active window, press <kbd>Tab</kbd> (can be configured via `Edit > Preferences> Shortcuts > TB`)
+- to make the previous window in this loop the active window, press <kbd>Shift</kbd>+<kbd>Tab</kbd> (can be configured via `Edit > Preferences> Shortcuts > BT`)
 
-- Move the cursor over/after `<object name>` and enter the Edit command (`<ED>`)
-- Double-click on/after `<object name>`
-
-By default, the **Edit** window is docked to the right of the **Session Window**.
-
-### Toolbar (Edit Window)
-
-The Edit Window's toolbar exposes the following actions:
-
-| Icon | Action | Description |
-| --- | --- | --- |
-| ![Save and close](img/screenshots/s_Tracewin_quitfunction.png) | Save changes and return | Saves changes and closes the Edit Window. |
-| ![Toggle line numbers](img/screenshots/i_Editwin_togglelinenumbers.png)| Toggle line numbers | Turns the display of line numbers on/off. |
-| ![Comment selected](img/screenshots/i_Editwin_commenttext.png) | Comment selected text | Add a comment symbol (`⍝`) to the beginning of the line in which the cursor is positioned. If text has been selected, then a comment symbol is added at the start of the line on which the selection starts and at the start of each subsequent line of text within the selection. Same as the Comment Out command (`<AO>`). |
-| ![Uncomment selected](img/screenshots/i_Editwin_uncommenttext.png) | Uncomment selected text | Removes the comment symbol (`⍝`) at the beginning of the line in which the cursor is positioned. If text has been selected, then comment symbols are removed from the start of each selected line of text. Comment symbols that are not at the start of a line of text cannot be removed. Same as the Uncomment command (`<DO>`). |
-| ![Search](img/screenshots/i_Editwin_search.png) | Search | Opens the [Search bar](search_and_replace_editwindow.md), enabling a search to be performed. |
-
-### Search and Replace (Edit Window)
-
-The <img src="../img/screenshots/i_intext_search.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> icon in the **Edit** window's toolbar opens the Search bar, enabling a search for every occurrence of a specified string (this can include APL glyphs) to be performed within the code in the Edit window; optionally, a replacement string can be applied on an individual basis.
-
-<img src="../img/screenshots/i_Editwindow_Searchbar.png" title="Placeholder image" alt="Placeholder image" style="border-left-style: solid;border-left-width: 1px;border-left-color: ;border-right-style: solid;border-right-width: 1px;border-right-color: ;border-top-style: solid;border-top-width: 1px;border-top-color: ;border-bottom-style: solid;border-bottom-width: 1px;border-bottom-color: ;" />
-
-The <img src="..img/screenshots/i_Searchbar_togglereplace.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> icon (Toggle replace mode) extends the Search bar to include a Replace field and related icons, as shown below.
-
-<img src="../img/screenshots/i_Editwindow_Searchbar_extended.png" title="Placeholder image" alt="Placeholder image" style="border-left-style: solid;border-left-width: 1px;border-left-color: ;border-right-style: solid;border-right-width: 1px;border-right-color: ;border-top-style: solid;border-top-width: 1px;border-top-color: ;border-bottom-style: solid;border-bottom-width: 1px;border-bottom-color: ;" />
-
-| Icon | Action | Description |
-| --- | --- | --- |
-| ![Previous](img/screenshots/i_Searchbar_previousmatch.png) | Search for previous match | Positions the cursor at the previous occurrence of the Search text. |
-| ![Next](img/screenshots/i_Searchbar_nextmatch.png) | Search for next match | Positions the cursor at the next occurrence of the Search text. |
-| ![Find in selection](img/screenshots/i_Searchbar_findinselection.png) | Find in selection | Only searches within the selected text. |
-| ![Close](img/screenshots/i_searchbar_close.png)| Close | Closes the Search bar. |
-| ![Replace](img/screenshots/i_Searchbar_replace.png) | Replace | Replaces the selected text in the Edit window with the text specified in the Replace field of the Search bar and highlights the next match. |
-| ![Replace all](img/screenshots/i_Searchbar_replaceall.png) | Replace all | Replaces all occurrences of the text specified in the Find field of the Search bar with that specified in the Replace field of the Search bar. |
-
-The *Find* field includes three filters, as detailed below. Any combination of these filters can be applied when performing a search.
-
-| Icon | Action | Description |
-| --- | --- | --- |
-|  ![Match case](img/screenshots/i_searchbar_matchcase.png)| Match case | Applies a case-sensitive filter so that only occurrences that match the case of the string in the Find field are highlighted. |
-|  ![Whole word](img/screenshots/i_searchbar_matchwholeword.png)| Match whole word | Only highlights whole words that match the string in the Find field. Note: some glyphs are treated as punctuation when identifying "whole words", for example, `; : , { } [ ] ( )` |
-| ![Regex](img/screenshots/i_searchbar_useregularexpression.png) | Use regular expression | Allows regular expressions to be specified in the Find field. |
-
----
-**To search for a string**
-
-1. Enter the string to search for in the Find field in one of the following ways:
-    - Press the Search button <img src="../img/screenshots/i_intext_search.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> and enter the string directly in the Find field.
-    - Enter the *Search* command (`<SC>`) and enter the string directly in the *Find* field.
-    - Select the string in the Trace window and enter the Search command (`<SC>`) or press the Search button ; the selected string is copied to the Find field.
-
-    All occurrences of the specified string are highlighted in the Edit window and the number of occurrences is displayed to the right of the Find field. If the content of the Edit window is sufficiently long for there to be a vertical scroll bar, then the locations of occurrences of the specified string within the entire content are identified by yellow marks overlaid on the scroll bar.
-
-2. Press the <kbd>Enter</kbd> key to select the first occurrence of the search string after the last position of the cursor.
-3. Press the **Search for next match** button <img src="../img/screenshots/i_intext_searchnextmatch.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> to advance the selection to the next occurrence of the search string.
-4. Repeat step 3 as required (the search is cyclic).
-5. Press the <kbd>Esc</kbd> key to exit the search functionality.
-
----
-
----
-**To replace a string**
-
-1. Do one of the following:
-    - Enter the string to search for in the <em>Find</em> field in one of the following ways:
-        - Press the **Search** button <img src="../img/screenshots/i_intext_search.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> and enter the string directly in the *Find* field.
-        - Enter the Search command (`<SC>`) and enter the string directly in the *Find*</em>* field.
-        - Select the string in the **Edit** window and enter the Search command (`<SC>`) or press the **Search** button <img src="../img/screenshots/i_intext_search.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" />; the selected string is copied to the *Find* field.
-        
-        Press <img src="../img/screenshots/i_Searchbar_togglereplace.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> to extend the Search bar to display the *Replace* field.
-
-        - Enter the Replace command (`<RP>`) and enter the string directly in the *Find* field.
-        - Select the string in the **Edit** window and enter the Replace command (`<RP>`); the selected string is copied to the *Find* field and the *Replace* field is displayed.
-
-2. Enter the replacement string directly in the *Replace* field.
-3. Press the <kbd>Enter</kbd> key to select the first occurrence of the search string after the last position of the cursor.
-4. Do one of the following:
-    - Press the <kbd>Enter</kbd> key or the **Replace** button <img src="../img/screenshots/i_Searchbar_replace.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> to replace the selected occurrence of the search string and to advance the selection to the next occurrence of the search string.
-    - Press the **Search** for next match** button <img src="../img/screenshots/i_intext_searchnextmatch.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> to leave the selected occurrence of the search string unaltered and to advance the selection to the next occurrence of the search string.
-    - Press the **Replace all** button <img src="../img/screenshots/i_Searchbar_replaceall.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> to replace all occurrences of the search string.
-5. Press the **Close** button to exit the search and replace functionality.
-
----
-
-### Exiting the Edit Window
-
-To save changes and close the **Edit** window:
-
-- click <img src="../img/screenshots/i_intext_close.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> in the **Edit** window's tab and select yes when prompted whether to save changes
-- click <img src="../img/screenshots/i_intext_quit.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 14px;" /> in the **Edit** window's toolbar
-- use the *Escape* command (`<EP>`)
-
-To close the Edit window without saving changes:
-
-- click <img src="../img/screenshots/i_intext_close.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> in the *Edit* window's tab and select no when prompted whether to save changes
-- use the *Quit* command (`<QT>`)
-
-## Trace Window
-
-The **Trace** window aids debugging by enabling you to step through your code line by line, display variables in **Edit** windows and watch them change as the execution progresses. Alternatively, you can use the **Session** window and **Edit** windows to experiment with and correct your code.
-
-A **Trace** window can be opened from the Session window by entering `<expression>` `<TC>`. This is an explicit trace and lets you step through the execution of any non-primitive functions/operators in the expression.
-
-By default, Dyalog is also configured to initiate an automatic trace whenever an error occurs, that is, the **Trace** window opens and becomes the active window and the line that caused the execution to suspend is selected. This is controlled by the interpreter configuration parameter `TRACE_ON_ERROR`. For information on configuration parameters, see the Dyalog Installation and Configuration Guide for your operating system:
-
-- [macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)
-- [Microsoft Windows Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20Microsoft%20Windows%20Installation%20and%20Configuration%20Guide.pdf)
-- [UNIX Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20UNIX%20Installation%20and%20Configuration%20Guide.pdf)
-
-By default, the **Trace** window is docked beneath the **Session** and **Edit** windows. Other than setting/removing [breakpoints](breakpoints.md), **Trace** windows are read-only.
-
-### Toolbar (Trace Window)
-
-The Trace Window's toolbar exposes the following actions:
-
-| Icon | Action | Description |
-| --- | --- | --- |
-| ![Quit](img/screenshots/s_Tracewin_quitfunction.png) | Quit this function | Cuts the execution stack back one level. |
-| ![Toggle line numbers](img/screenshots/i_Editwin_togglelinenumbers.png) | Toggle line numbers | Turns the display of line numbers on/off. |
-| ![Execute line](img/screenshots/s_Tracewin_execute.png) | Execute line | Executes the current line and advances to the next line. |
-| ![Trace](img/screenshots/s_Tracewin_trace.png) | Trace into expression | Traces execution of the current line and advances to the next line. If the current line calls a user-defined function then this is also traced. |
-| ![Stop on next line](img/screenshots/s_Tracewin_stoponnextline.png)  | Stop on next line of calling function | Continues execution of the code in the Trace window from the current line to completion of the current function or operator. If successful, the selection advances to the next line of the calling function (if there is one). |
-| ![Continue this thread](img/screenshots/s_Tracewin_continue.png) | Continue execution of this thread | Closes the Trace window and resumes execution of the current application thread from the current line. |
-| ![Continue all threads](img/screenshots/s_Tracewin_continueall.png)  | Continue execution of all threads | Closes the Trace window and resumes execution of all suspended threads. |
-| ![Interrupt](img/screenshots/s_Tracewin_interrupt.png)  | Interrupt | Interrupts execution with a weak interrupt. |
-| ![Edit name](img/screenshots/s_Tracewin_editname.png) | Edit name | Converts the Trace window into an Edit window as long as the cursor is on a blank line or in an empty space. However, if the cursor is on or immediately after an object name that is not the name of the suspended function, then an Edit window for that object name is opened. |
-| ![Clear all breakpoints](img/screenshots/s_Tracewin_clearbreakpoints.png) | Clear stops for this object | Clears all breakpoints (resets `⎕STOP` ) on the function(s) in the Edit / Trace windows. |
-| ![Search](img/screenshots/i_Editwin_search.png) | Search | Opens the Search bar, enabling a search to be performed. |
-
-### Search (Trace Window)
-
-The <img src="../img/screenshots/i_intext_search.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> icon in the **Trace** window's toolbar opens the Search bar, enabling a search for every occurrence of a specified string (this can include APL glyphs) to be performed within the code in the **Trace** window.
-
-The Search bar exposes the following actions:
-
-| Icon | Action | Description |
-| --- | --- | --- |
-| ![Previous](img/screenshots/i_Searchbar_previousmatch.png) | Search for previous match | Positions the cursor at the previous occurrence of the Search text. |
-| ![Next](img/screenshots/i_Searchbar_nextmatch.png) | Search for next match | Positions the cursor at the next occurrence of the Search text. |
-| ![Find in selection](img/screenshots/i_Searchbar_findinselection.png) | Find in selection | Only searches within the selected text. |
-| ![Close](img/screenshots/i_searchbar_close.png)| Close | Closes the Search bar. |
-| ![Replace](img/screenshots/i_Searchbar_replace.png) | Replace | Replaces the selected text in the **Trace** window with the text specified in the Replace field of the Search bar and highlights the next match. |
-| ![Replace all](img/screenshots/i_Searchbar_replaceall.png) | Replace all | Replaces all occurrences of the text specified in the Find field of the Search bar with that specified in the Replace field of the Search bar. |
-
-The *Find* field includes three filters, as detailed below. Any combination of these filters can be applied when performing a search.
-
-| Icon | Action | Description |
-| --- | --- | --- |
-|  ![Match case](img/screenshots/i_searchbar_matchcase.png)| Match case | Applies a case-sensitive filter so that only occurrences that match the case of the string in the Find field are highlighted. |
-|  ![Whole word](img/screenshots/i_searchbar_matchwholeword.png)| Match whole word | Only highlights whole words that match the string in the Find field. Note: some glyphs are treated as punctuation when identifying "whole words", for example, `; : , { } [ ] ( )` |
-| ![Regex](img/screenshots/i_searchbar_useregularexpression.png) | Use regular expression | Allows regular expressions to be specified in the Find field. |
-
----
-**To search for a string**
-
-1. Enter the string to search for in the Find field in one of the following ways:
-    - Press the Search button <img src="../img/screenshots/i_intext_search.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> and enter the string directly in the Find field.
-    - Enter the *Search* command (`<SC>`) and enter the string directly in the *Find* field.
-    - Select the string in the **Trace** window and enter the Search command (`<SC>`) or press the Search button ; the selected string is copied to the Find field.
-
-    All occurrences of the specified string are highlighted in the **Trace** window and the number of occurrences is displayed to the right of the Find field. If the content of the **Trace** window is sufficiently long for there to be a vertical scroll bar, then the locations of occurrences of the specified string within the entire content are identified by yellow marks overlaid on the scroll bar.
-
-2. Press the <kbd>Enter</kbd> key to select the first occurrence of the search string after the last position of the cursor.
-3. Press the **Search for next match** button <img src="../img/screenshots/i_intext_searchnextmatch.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> to advance the selection to the next occurrence of the search string.
-4. Repeat step 3 as required (the search is cyclic).
-5. Press the <kbd>Esc</kbd> key to exit the search functionality.
-
-### Exiting the Trace Window
-
-To close the **Trace** window:
-
-- click <img src="../img/screenshots/i_intext_close.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> in the **Trace** window's tab
-- click <img src="../img/screenshots/i_intext_quit.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 14px;" /> in the **Trace** window's toolbar
-- use the *Escape* command (`<EP>`)
-- use the *Quit* command (`<QT>`)
-- press the <kbd>Esc</kbd> key
-
-When the **Trace** window is closed, the function within that **Trace** window is removed from the stack. It is possible to close all **Trace/Edit** windows without clearing the stack by selecting the `Window > Close All Windows` menu option or using [2023⌶](https://help.dyalog.com/latest/index.htm#Language/I%20Beam%20Functions/Close%20All%20Windows.htm?Highlight=2023%E2%8C%B6).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+You can close all **Trace/Edit** windows without clearing the stack by selecting the `Window > Close All Windows` menu option or using [2023⌶](https://help.dyalog.com/latest/index.htm#Language/I%20Beam%20Functions/Close%20All%20Windows.htm?Highlight=2023%E2%8C%B6).
 
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,119 +1,66 @@
 # Installation
 
-This chapter describes how to install the RIDE.
+## Font and Keyboard Support
 
-## Pre-requisites
+If Dyalog is not installed on the machine that RIDE is being installed on, then the APL385 Unicode font and keyboard mappings installed with RIDE mean that they are available within RIDE. However, to be able to enter APL glyphs outside RIDE, see [APL Fonts and Keyboards](https://www.dyalog.com/apl-font-keyboard.htm).
 
-RIDE can only connect to a Dyalog interpreter that is version 15.0 or later.
+## Zero-Footprint
 
-The RIDE is supported on the following operating systems:
-
-- Linux x86_64 – the following distributions: 
-    - Debian 8 onwards
-    - Fedora 25 onwards
-    - Ubuntu 14.04 onwards
-
-    distributions built on top of these should also work (Linux distribution must also have libnss version 3.26 onwards)
-    
-- macOS – Yosemite onwards
-- Microsoft Windows – Windows 7 onwards
-
-For the zero-footprint RIDE:
-
-- a compatible browser must be installed.
-- the operating system must be supported by the underlying [technology](https://electronjs.org).
-
-If Dyalog is not installed on the machine that the RIDE is being installed on, then the APL385 font and keyboard mappings installed with the RIDE mean that they are available when running a Dyalog Session through the RIDE. However, to be able to enter APL glyphs outside a Dyalog Session (for example, in text files or emails) you will need to download and install the [appropriate files](https://www.dyalog.com/apl-font-keyboard.htm) for your system.
-
-## Installing the RIDE
-
-Installation instructions are dependent on operating system.
-
-### Zero Footprint
-
-The use of the RIDE from a browser requires no installation on the machine where the RIDE will run. However, the RIDE must be installed on the machine where APL is installed, so that Dyalog can act as a web server, making the necessary files available to the browser.
+The use of RIDE from a browser requires no installation on the machine where RIDE will run; all you need is a  modern browser.
 
 !!!note
-    When installing the RIDE, if you select the default location suggested by the installer then APL can be launched as a RIDE server without creating a [configuration file](sample_configuration_file.md).
+    When installing RIDE, if you select the default location suggested by the installer then APL can be launched as a RIDE server without creating a [configuration file](sample_configuration_file.md).
 
-On non-Windows platforms, the Zero Footprint RIDE is automatically installed to the default location (**[DYALOG]/RIDEapp**) when Dyalog is installed and no additional installation is necessary to use the [Zero Footprint RIDE](the_zero_footprint_ride.md) from a browser.
+On non-Windows platforms, zero-footprint RIDE is automatically installed to the default location (**[DYALOG]/RIDEapp**) when Dyalog is installed and no additional installation is necessary. On Windows, zero-footprint RIDE needs separate installation.
 
-### Installing on Linux
+For details, see [Zero Footprint RIDE](the_zero_footprint_ride.md).
 
-The installation process for the RIDE is the same irrespective of whether it is installed as a stand-alone product or on a machine that already has Dyalog installed.
+## Linux
 
----
-**To install the RIDE**
+RIDE requires Debian 8+, Fedora 14.04+, or Ubuntu 10.10+. Distributions built on top of the above should also work, provided that they have libnss version 3.26 or newer.
 
-1. Download the RIDE's **.deb** or **.rpm** file (whichever is appropriate for your Linux distribution) from the [RIDE releases page](https://github.com/Dyalog/ride/releases). If your Linux distribution does not support either **.deb** or **.rpm** files, then please contact support@dyalog.com.
+1. Download the **.deb** or **.rpm** file (whichever is appropriate for your Linux distribution) from the [RIDE releases page](https://github.com/Dyalog/ride/releases). If your Linux distribution does not support either **.deb** or **.rpm** files, then please contact support@dyalog.com.
 2. From the command line, use standard installation commands to install the package.
 
-    The RIDE is now installed and ready to use. The RIDE icon (shortcut) is added to the desktop.
+A RIDE shortcut is added to the desktop.
 
----
+## macOS
 
-### Installing on macOS
+RIDE requires macOS Yosemite (10.10) or better.
 
 The RIDE is the default UI for Dyalog on macOS and is installed at the same time as Dyalog (see the [Dyalog for macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)); no further installation is required.
 
----
-**To install the RIDE as a separate, stand-alone, product**
+You can also install RIDE as a separate, stand-alone, product, for example to work exclusively with remote APL interpreters:
 
-1. Download the RIDE's **.pkg** file from the [RIDE releases page](https://github.com/Dyalog/ride/releases).
-2. Double-click on the RIDE's **.pkg** file.
+1. Download the **.pkg** file from the [RIDE releases page](https://github.com/Dyalog/ride/releases).
+2. Double-click on RIDE's **.pkg** file.
+3. Follow the instructions.
 
-    The **RIDE Installer** window is displayed.
+RIDE is added to the **Applications** directory (accessed by selecting **Applications** from the **Go** menu in the **Finder** menu bar, or by activating Spotlight with <kbd>⌘</kbd>+<kbd>Space</kbd> and typing RIDE).
 
-3. Follow the instructions in the RIDE Installer window to successful completion of the installation process.
+Starting RIDE will add RIDE's icon to the temporary "Recently Used Apps" area to the right of the dock. To keep the RIDE icon in the dock permanently, right-click on the icon and select `Options > Keep in Dock` from the drop-down list that appears.
 
-    The RIDE is now installed and ready to use. The RIDE icon is added to the **Applications** directory (accessed by selecting **Applications** from the **Go** menu in the **Finder** menu bar).
+## Windows
 
----
+RIDE requires Windows 7 or newer.
 
-Starting the RIDE adds its icon to the dock. To keep the RIDE icon in the dock permanently, right-click on the icon and select **Options > Keep in Dock** from the drop-down list that appears.
-
-### Installing on Microsoft Windows
-
-The installation process for the RIDE is the same irrespective of whether it is installed as a stand-alone product or on a machine that already has Dyalog installed.
-
----
-**To install the RIDE**
-
-1. Download the RIDE's **.zip** file from the [RIDE releases page](https://github.com/Dyalog/ride/releases).
+1. Download the **.zip** file from the [RIDE releases page](https://github.com/Dyalog/ride/releases).
 2. Unzip the downloaded **.zip** file, placing the `setup_ride.exe` and `setup_ride.msi` files in the same location as each other.
 3. Double-click on the `setup_ride.exe` file.
+4. Follow the instructions.
 
-    The **RIDE Installation window** is displayed.
-4. Follow the instructions in the RIDE Installation window to successful completion of the installation process.
-
-    The RIDE is now installed and ready to use. The RIDE icon (shortcut) is added to the desktop.
-    
----
+A RIDE shortcut is added to the desktop
 
 ## Configuration (.ini) File
 
 A **.ini** configuration file can be used to define settings for the `RIDE_INIT` configuration parameter. By default, the interpreter will look for a **ride.ini** file in:
 
 -  the directory in which the default session and log files are stored, for example, **C:\Users\JohnDoe\AppData\Local\Programs\Dyalog** (on Microsoft Windows)
-- **$HOME/.dyalog** (on IBM AIX, macOS and Linux)
+- **$HOME/.dyalog** (on all other platforms)
 
 This file is not automatically created by Dyalog but can be created manually. Examples of the fields that you might want to include within the **.ini** configuration file are included in the [sample configuration file](sample_configuration_file.md).
 
 A different name and location for the .ini configuration file can be specified by including a second `mode`, `CONFIG`, in the [RIDE_INIT](ride_init.md) parameter and setting it so that `CONFIG=<filename>`, where `<filename>` is the fully-qualified path to, and name of, a **.ini** configuration file containing name-value pairs related to mode, certificate details, and so on.
 
 !!!note
-    The **.ini** configuration file must be located on the machine on which the interpreter is running (this is not necessarily the same machine as the one on which the RIDE is running).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    The **.ini** configuration file must be located on the machine on which the interpreter is running (this is not necessarily the same machine as the one on which RIDE is running).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,24 +1,12 @@
 # Introduction
 
 !!!note
-    The use of the RIDE is subject to the conditions of the [MIT licence](https://github.com/Dyalog/ride/blob/master/licence). The installation and use of the RIDE does not convey any additional rights to use Dyalog or any other Dyalog products. Specifically, although the interpreter can be configured to allow the RIDE to debug runtime executables, you should only do this if your Dyalog licence also allows it.
+    The use of RIDE is subject to the conditions of the [MIT licence](https://github.com/Dyalog/ride/blob/master/licence). The installation and use of RIDE does not convey any additional rights to use Dyalog or any other Dyalog products. Specifically, although the interpreter can be configured to allow RIDE to debug runtime executables, you should only do this if your Dyalog licence also allows it.
 
-The Remote Integrated Development Environment (RIDE) is a cross-platform, graphical development environment capable of producing a rich user experience on a variety of platforms. It supports the interactive use of APL notation to explore data, discover algorithms and create solutions – or diagnose problems, resolve issues and resume the execution of running applications.
+RIDE is a cross-platform, graphical development environment capable of producing a rich user experience. With it, you can use APL interactively to explore data, discover algorithms and create solutions – or diagnose problems, resolve issues and resume the execution of running applications.
 
-The RIDE runs separately from the APL interpreter, and communicates with it using TCP/IP sockets. The RIDE can be run on macOS, Microsoft Windows and Linux (including the Raspberry Pi). In addition to being used as a front end for APL running locally, it can also be used to launch APL sessions on remote machines or to connect to APL interpreters that are already running – either locally or remotely.
+RIDE runs separately from the APL interpreter, but can communicate with any local or remote APL session. It can launch APL sessions on remote machines or to connect to APL interpreters that are already running.
 
-From Dyalog version 17.0, the interpreter can easily be configured to act as a web server which provides the RIDE application as a web page. This makes it possible to run the RIDE in a browser on any platform, without installing it locally. The RIDE needs to be installed on the machine where the interpreter is running, so the files can be provided as a webpage. Because no client-side installation is necessary, this mode is known as Zero Footprint.
+An interpreter can also provide RIDE's interface as a web page. This makes it possible to control a remote interpreter thorugh a browser, without installing RIDE on your machine. For this zero-footprint mode to work on Windows, RIDE needs to be installed on the machine where the interpreter is running, however, it comes with the interpreter installation on all other platforms.
 
-The RIDE has two main modes of use:
-
-- Providing a user interface to an interpreter engine (local or remote).
-
-    The RIDE is the recommended IDE for Dyalog on macOS or Linux (including the Raspberry Pi). In these environments, an application icon is provided to launch RIDE and an APL interpreter together. In this mode, the RIDE and the interpreter can be thought of as a single unit. Under Microsoft Windows, the native Dyalog IDE continues to provide the richest environment for the development of APL applications for Microsoft Windows users.
-
-- As a tool for managing connections to a collection of interpreter sessions.
-
-    In this mode, the RIDE-Dyalog Session dialog box is used to launch or connect to one or more interpreters.
-    
-    !!!note
-        Although the RIDE can manage multiple concurrent Dyalog Sessions, each Dyalog Session can only be connected to a single instance of the RIDE at any one time.
-
+On Windows, the interpreter has a built-in IDE, which continues to provide the richest environment, however, RIDE the recommended interface on all other platforms.

--- a/docs/starting_a_dyalog_session.md
+++ b/docs/starting_a_dyalog_session.md
@@ -1,322 +1,61 @@
 # Starting a Dyalog Session
 
 !!!note
-    When running a Dyalog Session through the RIDE, that Session should only be accessed through the RIDE. One exception to this rule is when developing or running applications that are `⎕SM`/`⎕SR` based; access to the `⎕SM` window cannot be made through the RIDE.
+    When running a Dyalog Session through RIDE, that Session should only be accessed through RIDE. One exception to this rule is when developing or running applications that are `⎕SM`/`⎕SR` based; access to the `⎕SM` window cannot be made through RIDE.
 
-When running a Dyalog Session through the RIDE, the Session can be:
+When running a Dyalog Session through RIDE, the Session can be:
 
-- local to the machine on which the RIDE is running. 
+- local to the machine on which RIDE is running. 
     
-    This requires Dyalog to be installed on the machine on which the RIDE is running.
+    This requires Dyalog to be installed on the machine on which RIDE is running.
 
-- remote from the machine on which the RIDE is running.
+- remote from the machine on which RIDE is running.
 
-    The RIDE can start a Session using an interpreter installed on a remote machine irrespective of whether Dyalog is installed on the machine on which the RIDE is running. In this situation:
+    The RIDE can start a Session using an interpreter installed on a remote machine irrespective of whether Dyalog is installed on the machine on which RIDE is running. In this situation:
 
-    - The operating system on which the remote interpreter is running is irrelevant – the instructions given in this chapter apply to the operating system on which the RIDE is running (the two operating systems do not have to be the same).
-    - The remote machine does not need to have the RIDE installed but the Dyalog Session must be [RIDE-enabled](ride_init.md).
+    - The operating system on which the remote interpreter is running is irrelevant – the instructions given in this chapter apply to the operating system on which RIDE is running (the two operating systems do not have to be the same).
+    - The remote machine does not need to have RIDE installed but the Dyalog Session must be [RIDE-enabled](ride_init.md).
 
-Connections between the RIDE and Dyalog interpreters are initialised through the **RIDE-Dyalog Session** dialog box. The exception to this is Zero Footprint use, which always requires Dyalog to be started first with suitable configuration parameters, after which the RIDE will appear when you direct a web browser at the APL interpreter. See [Zero Footprint Ride](the_zero_footprint_ride.md) for more information on Zero Footprint mode.
+Normally, connections between RIDE and interpreters are initialised from the **New Session** window. The exception to this is zero-footprint use, which always requires Dyalog to be started first with suitable configuration parameters, after which RIDE will appear when you direct a web browser at the APL interpreter. See [Zero Footprint Ride](the_zero_footprint_ride.md) for details.
 
-This chapter describes how to use the RIDE to run Dyalog Sessions, both local and remote.
 
-## The RIDE-Dyalog Session Dialog Box
+## New Session screen
 
-When the RIDE is started, the **RIDE‑Dyalog Session** dialog box is displayed. The **RIDE‑Dyalog Session** dialog box comprises four areas, as shown below:
+The **New Session** window is displayed when RIDE starts, unless disabled in the preferences (the default on macOS). This window allows simple and advanced use.
 
-- the menu bar
-- the list of configurations
-- the basic information for the configuration selected in the configuration list
-- the type-dependent information for the configuration selected in the configuration list
+### Simple usage
 
-![RIDE-Dyalog Session dialog box](img/screenshots/s_connect_connecttoaninterpreter_labelled.png)
+Click |> for the configuartion you want to launch. Configurations for all locally installed Dyalog versions are automatically shown. 
 
-### Menu Bar
+### Advanced usage
 
-!!!note
-    The RIDE's UI can vary slightly across different operating systems (and window managers); in particular, RIDE-specific menu bars can be located either within the development environment or in the global menu bar.
+You can add new custom configurations (for example for remote interpreters) by clicking <kbd>NEW CONFIGURATION…</kbd>.
 
-The options available under the **Dyalog** menu are detailed here:
+You can modify an existing configuration by selecting it and clicking <kbd>CUSTOM OPTIONS</kbd>.
 
-| Item | Description |
-| --- | --- |
-| About Dyalog | Displays the **About** dialog box, which provides details of the RIDE. |
-| Preferences | Opens the [Preferences](preferences_dialog_box.md) dialog box. |
-| Quit | Closes the **RIDE-Dyalog Session** dialog box. |
+Either of these will open the advanced configuration pane where you can choose connection type and protocol, provide the interpreter with arguments and configuration parameters, and more.
 
-The options available under the **Edit** menu are detailed here:
+For example:
 
-| Item | Description |
-| --- | --- |
-| Undo | Reverses the previous action (where possible). |
-| Redo | Reverses the effect of the previous Undo. |
-| Cut | Deletes the selected text and places it on the clipboard. |
-| Copy | Copies the selected text to the clipboard. |
-| Paste | Pastes the text contents of the clipboard into the current location. |
-| Select All | Selects all the text in the field in which the cursor is positioned. If the cursor is not within a field, then selects the text in all fields. |
+* If you want RIDE to connect to a remote interpreter that has been started with the configuration parameter `RIDE_INIT="SERVE:*:4502"` then create a new configuration of type "Connect", then specify IP address and port 4502.
+* If you want RIDE to await an incoming connection from a remote interpreter that will be started with the configuration parameter `RIDE_INIT="CONNECT:jaypc.dyalog.bramley:4502"` (where your address is `jaypc.dyalog.bramley`) then choose "Listen", and specify port 4502.
 
-### List of Configurations
+## Zero-Footprint Mode
 
-The list of configurations lists the names of previously-saved configurations. By default, a placeholder configuration called unnamed is present in the list of configurations with the Type set to Connect.
+Dyalog can serve RIDE to any modern web browser – this is known as "zero-footprint" operation since RIDE is not installed on the client machine but is downloaded by the web browser on demand. The advantage is that an APL session can be monitored and maintained from any device without installing anything.
 
-Selecting a configuration from this list displays its basic information and type dependent information.
+This mode has the following limitations:
 
-At the bottom of the list of configurations is a bar containing four buttons:
-
-![Button bar](img/screenshots/s_listofconfigs_buttonbar.png)
-
-The list of configurations' button bar
-
-| Button | Name | Description |
-| --- | --- | --- |
-| ![New](img/screenshots/i_configlist_new.png) | New | Creates a new entry in the **list of configurations**. The default name for a new configuration is *unnamed*. |
-| ![Clone](img/screenshots/i_configlist_clone.png) | Clone | Creates an exact copy of the configuration currently selected in the **list of configurations**. Details can then be changed in the cloned configuration without impacting the original. |
-| ![Delete](img/screenshots/i_configlist_delete.png) | Delete | Prompts for confirmation before deleting the configuration currently selected in the **list of configurations**. |
-| ![Save](img/screenshots/i_configlist_save.png) | Save | Saves all items in the **list of configurations**. |
-
-In addition to the buttons, the following actions can be performed when a configuration is selected in the **list of configurations**:
-
-- activate the configuration
-
-    Click **CONNECT/START/LISTEN** (as appropriate) in the basic information area to start a Dyalog Session through the RIDE.
-
-- amend the configuration
-    
-    Change details in the basic or type-dependent information areas. Changes must be saved to be retained between RIDE sessions.
-
-A configuration can also be activated by clicking the <img src="../img/screenshots/b_connectdialog_play.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px; height: 10px;" /> button to the right of its name in the list of configurations.
-
-### Types
-
-The Type can be one of three options (selected from a drop-down list). The type that is selected determines the content of the type-dependent area. The options are:
-
-- [Start](type_start.md) – the RIDE initiates and connects with a new local or remote interpreter
-- [Connect](type_connect.md) – a specific (local or remote) Dyalog interpreter is sought by the RIDE for connection
-- [Listen](type_listen.md) – the RIDE waits for a local or remote interpreter to connect to it
-
-Selecting a configuration from this list displays its basic information and type dependent information.
-
-#### Start
-
-The most common use of the RIDE is where the RIDE launches an APL interpreter process and connects to it. The RIDE allocates a random TCP port and instructs the launched interpreter to connect to it immediately. The RIDE is also able to launch remote processes on machines that support Secure Shell (SSH) logins, in which case the communication between the RIDE and the interpreter is also encrypted.
-
----
-**To start a Dyalog Session**
-
-1. Open the **RIDE-Dyalog Session** dialog box.
-2. Select Start from the Type drop-down list.
-3. Optionally, check **Save protocol log** – this  records all communications between the interpreter and the RIDE. The default path/filename for this interpreter‑independent protocol log can be changed.
-4. Select a security protocol from the drop-down list.
-
-    The type-dependent information fields are displayed:
-    
-    - If the security protocol is set to Local: then the RIDE can only initiate and connect with a local interpreter:
-    
-        - **Interpreter**: the interpreter to initiate an instance of, selected from a drop-down list comprising all versions of Dyalog that are installed on the machine that the RIDE is running on; versions that are installed but not supported by the RIDE are listed but not enabled. If the path and/or name of the interpreter have been amended from the default installation values, then they might not appear in the drop-down list. An interpreter in this situation can be chosen by selecting <em>Other…</em> in the drop-down list and entering its full path in the **path to executable** field. The value of the **path to executable** field is remembered across invocations of the RIDE.
-        - **Working directory**: optionally, specify the fully-qualified path to, and name of, a directory that overrides the interpreter's default working directory.
-        - **Arguments**: optionally, specify additional arguments for the interpreter (one argument per line).
-        - **Environment variables**: optionally, specify additional configuration parameters for the interpreter. These should be specified as &lt;key&gt;=&lt;value&gt; pairs, with one pair per line, no extra spaces and no quoting or escaping of value.
-
-    - If the security protocol is set to **SSH** then the RIDE connects to a local or remote interpreter using the secure shell network protocol:
-
-        !!!note
-            The use of SSH is not applicable when the interpreter is running on the Microsoft Windows operating system.
-
-        - **Host**: the IP address/unique DNS name of the machine that the interpreter will be running on.
-        - **Port**: the number of the port that the RIDE and the interpreter will connect through. By default, this is port 4502.
-        - **SSH Port**: the number of the port to use for SSH. The default is 22.
-        - **User**: the user name on the machine that the interpreter is running on.
-        - **Key file**: the fully-qualified filename of the SSH identity file.
-        - **Password/passphrase**: either the password corresponding to the specified **User** or, if an encrypted key file is being used for authentication, the passphrase.
-        
-            - If an encrypted **Key File** is specified, a passphrase is required for authentication.
-            - If an unencrypted **Key File** is specified, a password/passphrase is not required.
-            - If a **Key File** is not specified, then the password corresponding to the specified User is required.
-
-        - **Interpreter**: the interpreter to initiate an instance of, selected from a drop-down list comprising all versions of Dyalog installed on the machine specified in the Host field (click the <img src="../img/screenshots/b_fetchlistofinterpreters.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px; height: 10px;" /> button to populate this list). The path to the interpreter selected in the drop-down list is displayed in the **path to executable** field. If the required interpreter is not included in the drop-down list, select **Other…** in the drop-down list and enter its fully-qualified path in the **path to executable** field. The value of the **path to executable** field is remembered across invocations of the RIDE.
-        - **Arguments**: optionally, specify additional arguments for the interpreter (one argument per line).
-        - **Environment variables**: optionally, specify additional configuration parameters for the interpreter. These should be specified as &lt;key&gt;=&lt;value&gt; pairs, with one pair per line, no extra spaces and no quoting or escaping of value.
-
-5. Click **START**.
-
----
-
-!!!note
-    In the Dyalog Session, selecting New Session in the [File menu](file_menu.md) launches another instance of the interpreter whose path is specified in the path to executable field.
-
-#### Connect
-
-The RIDE connects to a specific running (local or remote) Dyalog interpreter that is listening for connections. This is typically used when the RIDE is monitoring processes that have been started to provide some kind of service and to debug them if something unexpected happens.
-
-!!!warning
-    You should only configure a Dyalog interpreter to listen for connections if either of the following apply:
-    - you have a firewall that allows you specify which client machines will be able to connect
-    - you use a [configuration file](sample_configuration_file.md) to specify suitable security filters to limit access to the interpreter.
-
-    Your application can use [3502⌶](3502_ibeam_ride.md) to enable debugging when it is appropriate.
-
-    To safely experiment with configuring APL to listen for connections, leave the address field in the following examples empty, for example, `RIDE_INIT="SERVE::4502"`. If the address field is empty, then only local connections are allowed. The `*` used below instructs the interpreter to listen on all available network adapters.
-
----
-**To start a Dyalog Session**
-
-1. On the machine that the interpreter will run on, start a Dyalog Session, optionally specifying an IP address/DNS name and port that it will listen for RIDE connections on using the `RIDE_INIT` configuration parameter. If specified, this will override any `RIDE_INIT` values defined in a [configuration file](configuration_ini_file.md).
-
-    For example, if the RIDE is on a different machine and will connect to a Dyalog version 16.0 Unicode 64-bit interpreter through port 4502, then enter the following in a command window/at the command prompt:
-    
-    - on AIX:<br />`$ RIDE_INIT="SERVE:*:4502" /opt/mdyalog/16.0/64/unicode/p7/mapl`
-    - on Linux:<br />`$ RIDE_INIT="SERVE:*:4502" dyalog`
-    - on macOS:<br />`$ RIDE_INIT="SERVE:*:4502" /Dyalog/Dyalog-16.0.app/Contents/Resources/Dyalog/mapl`
-    - on Microsoft Windows:
-    
-            > cd "C:\Program Files\Dyalog\Dyalog APL-64 16.0 Unicode"
-            > dyalog RIDE_INIT=SERVE:*:4502
-
-        Alternatively, create a shortcut with the appropriate settings:
-        
-        1. Select the appropriate Dyalog installation and create a shortcut to it.
-        2. Right-click on the shortcut icon and select **Properties** from the context menu that is displayed.
-        
-            The **Properties** dialog box is displayed.
-        
-        3. In the **Shortcut** tab, go to the **Target** field and:
-        
-        - place `"` marks around the path (if not already present)
-        - append `RIDE_INIT=SERVE:*:4502`
-            
-            For example: `"C:\Program Files\Dyalog\Dyalog APL-64 16.0 Unicode\dyalog.exe" RIDE_INIT=SERVE:*:4502`
-
-        4. Click **OK**.
-
-2. On the machine that the RIDE is running on: 
-
-    1. Open the **RIDE-Dyalog Session** dialog box. 
-    2. Select Connect from the Type drop-down list. 
-    3. Optionally, check **Save protocol log** – this  records all communications between the interpreter and the RIDE. The default path/filename for this interpreter‑independent protocol log can be changed.
-    4. Select a security protocol from the drop-down list.
-
-        The type-dependent information fields are displayed.
-
-        - If the security protocol is set to **TCP**:
-            - **Host**: the IP address/unique DNS name of the machine that the interpreter is running on. 
-            - **Port**: the number of the port that the interpreter is listening on. By default, the interpreter listens on port 4502.
-        
-        - If the security protocol is set to **SSH** then the RIDE connects to a remote interpreter using the secure shell network protocol:
-
-            !!!warning
-                The use of SSH is not appropriate when the interpreter is running on the Microsoft Windows operating system.
-
-            - **Host**: the IP address/unique DNS name of the machine that the interpreter is running on.
-            - **Port**: the number of the port that the interpreter is listening on. By default, the interpreter listens on port 4502.
-            - **SSH Port**: the number of the port to use for SSH. The default is 22.
-            - **User**: the user name on the machine that the interpreter is running on.
-            - **Key file**: the fully-qualified filename of the SSH identity file.
-            - **Password/passphrase**: either the password corresponding to the specified **User** or, if an encrypted key file is being used for authentication, the passphrase.
-            
-                - If an encrypted **Key File** is specified, a passphrase is required for authentication.
-                - If an unencrypted **Key File** is specified, a password/passphrase is not required.
-                - If a **Key File** is not specified, then the password corresponding to the specified **User** is required.
-
-        - If the security protocol is set to **TLS/SSL** then secure connections are enabled:
-
-            !!!note
-                By default, the RIDE qualifies the server certificate using the root authority certificates available in the Microsoft Certificate Store
-
-            - **Host**: the IP address/unique DNS name of the machine that the interpreter is running on.
-            - **Port**: the number of the port that the interpreter is listening on. By default, the interpreter listens on port 4502.
-            - Three optional check boxes (and associated fields) are relevant if you have not added your root certificate to the Microsoft Certificate Store or are not running on the Microsoft Windows operating system:
-                - **Provide user certificate**: if selected, populate the Cert and Key fields with the fully-qualified paths to, and names of, the PEM encoded certificate file and key file respectively – the interpreter (RIDE server) uses this to verify that the RIDE client is permitted to connect to it.
-                - **Custom root certificates**: if selected, populate the **Directory** field with the fully-qualified path to, and name of, the directory that contains multiple root certificates and key files to use for authentication.
-                - **Validate server subject common name matches hostname**: verifies that the CN (Common Name) field of the server's certificate matches the hostname.
-
-5. Click **CONNECT**.
-
----
-
-#### Listen
-
-The RIDE waits for a local or remote interpreter to connect to it. This approach is more secure than configuring the interpreter to listen for connections, because an intruder will only be able to communicate with the RIDE rather than an APL system. An application that needs to be debugged can initiate the connection to a listening RIDE using [3502⌶](3502_ibeam_ride.md) to set `RIDE_INIT` when debugging is desired.
-
----
-**To start a Dyalog Session**
-
-1. On the machine that the RIDE is running on: 
-    1. Open the **RIDE-Dyalog Session** dialog box.
-    2. Select Listen from the Type drop down list.
-
-        The type-dependent information fields are displayed.
-        
-        - In the **Host** field, specify the IP address/unique DNS name that the RIDE will bind to. By default, the RIDE will bind to all interfaces.
-        - In the **Port** field, specify the number of the port that the RIDE should listen on. By default, the RIDE listens on port 4502.
-    3. Optionally, check **Save protocol log** – this  records all communications between the interpreter and the RIDE. The default path/filename for this interpreter‑independent protocol log can be changed. 
-    4. Click LISTEN.
-
-        The **Waiting for connection...** dialog box is displayed.
-
-2. On the machine that the interpreter will run on, start a Dyalog Session from the command prompt. When doing this, the IP address/DNS name for the machine that the RIDE is running on and the same port number as the RIDE is listening on must be specified as connection properties.
-
-    For example, if the RIDE is running on a machine that has DNS name `jaypc.dyalog.bramley` and is listening on port 4502, then enter the following in a command window/at the command prompt:
-
-    - AIX: `$ RIDE_INIT="CONNECT:jaypc.dyalog.bramley:4502" /opt/mdyalog/16.0/64/unicode/p7/mapl`
-    - Linux: `$ RIDE_INIT="CONNECT:jaypc.dyalog.bramley:4502" dyalog`
-    - macOS: `$ RIDE_INIT="CONNECT:jaypc.dyalog.bramley:4502" /Dyalog/Dyalog-16.0.app/Contents/Resources/Dyalog/mapl`
-    - Microsoft Windows: `> cd "C:\Program Files\Dyalog\Dyalog APL-64 16.0 Unicode" > dyalog RIDE_INIT=CONNECT:jaypc.dyalog.bramley:4502`
-
-    The Dyalog Session starts.
-
----
-
-Alternatively, start a Dyalog Session and enter:
-
-`3502⌶'CONNECT:jaypc.dyalog.bramley:4502' 3502⌶1`
-
-The new Dyalog Session will connect to the RIDE and remain connected until the Dyalog Session is terminated.
-
-!!! note
-    On Microsoft Windows, an alternative to using the command window is to create a shortcut with the appropriate settings.
-            
----
-**To configure the shortcut**
-
-1. Select the appropriate Dyalog installation and create a shortcut to it.
-2. Right-click on the shortcut icon and select **Properties** from the context menu that is displayed.
-
-    The **Properties** dialog box is displayed.
-
-3. In the Shortcut tab, go to the **Target** field and:
-    1. place **"** marks around the path 
-    2. append `RIDE_INIT=CONNECT:10.0.38.1:4502`
-
-    For example: `>"C:\Program Files\Dyalog\Dyalog APL-64 16.0 Unicode\dyalog.exe" RIDE_INIT=CONNECT:10.0.38.1:4502`
-
-4. place **"** marks around the path
-5. append `RIDE_INIT=CONNECT:10.0.38.1:4502`
-6. Click OK.
-
-## The Zero Footprint RIDE
-
-The RIDE is an application that is implemented using a combination of HTML and Javascript. A full RIDE installation includes a small web server framework called Node/JS, which acts as a host for the application, and an embedded web browser that renders it to the user as a desktop application.
-
-Dyalog is able to act as a web server, hosting the RIDE application and making it available to any compatible web browser – this is known as "Zero Footprint" operation as the RIDE is not installed on the client machine but is downloaded by the web browser on demand. The advantage of the Zero Footprint RIDE is that an APL session can be monitored and maintained from any device with a suitable browser installed; no installation of RIDE is required.
-
-The Zero Footprint RIDE provides the same features for viewing and developing APL code as the desktop RIDE, with the following limitations:
-
-- The Zero Footprint RIDE can only interact with the APL interpreter that it is connected to; none of the functionality related to launching new sessions or connecting to running APL sessions is available.
+- You can only interact with the APL interpreter that is serving you; the **New Session** window is not available.
 - Preferences are persisted in browser storage using cookies.
-- Behaviour that is provided by the browser (undo/redo, cut/copy/paste, change font size) does not appear in the RIDE's menus.
 - Window captions cannot be controlled.
+- The floating **Edit/Trace** windows option is not available.
 
----
-**To make the Zero Footprint RIDE available from a web browser**
+### Accessing Zero-Footprint RIDE from a browser
 
-1. Install Dyalog and the RIDE. These must both be installed on the same machine; the RIDE must be installed in its default location. On non-Windows platforms the Zero Footprint RIDE is automatically installed when Dyalog is installed. For information on installing the RIDE on Microsoft Windows, see [Installing on Windows](installing_on_windows.md)
+1. If on Windows, [install zero-footprint RIDE](installation.md/#windows)
 2. Set the `RIDE_INIT` configuration parameter to `HTTP:address:port` (see [RIDE Init](ride_init.md)), for example, `RIDE_INIT=HTTP:*:8080`.
 3. Start a Dyalog session.
-    
-    The Zero Footprint RIDE can now be accessed from a web browser by navigating to `http://<address>:<port>`, for example, `http://10.0.38.1:8080`.
+4. Navigate to `http://<address>:<port>`, for example, `http://10.0.38.1:8080`.
 
----
-
-On non-Windows platforms (IBM AIX, macOS and Linux), the interpreter expects to find the Zero Footprint RIDE files in the `[DYALOG]/RIDEapp` directory; this removes the need to include the `HttpDir` field in a [configuration file](installation.md#configuration-ini-file).
-
-
+On non-Windows platforms, the interpreter expects to find zero-footprint RIDE installed at the `[DYALOG]/RIDEapp` directory; this removes the need to include the `HTTPDIR` field in a [configuration file](installation.md#configuration-ini-file).

--- a/docs/the_dyalog_development_environment.md
+++ b/docs/the_dyalog_development_environment.md
@@ -1,314 +1,63 @@
 # The Dyalog Development Environment
 
-When a Dyalog Session is started through the RIDE, the Dyalog development environment is displayed. This means that:
+## Interactive Session Window
 
-- the [Dyalog Session](session_user_interface.md) user interface is displayed 
-- the [keyboard key mappings](keyboard_key_mappings_for_apl_glyphs.md) for APL glyphs are enabled
+RIDE's main interface is an interactive session, where you enter expressions and the interpreter prints results.
 
-## Session User Interface
+Along the left edge of the interactive session is a narrow area that shows input/output information. It indicates modified lines and code blocks (which will be executed next time you press <kbd>Enter</kbd>) and indicates which output lines belong together.
 
-!!!note "macOS"
-    The menu bar menu options on macOS are different to those on Microsoft Windows and Linux. This section details the options for Microsoft Windows and Linux; for the macOS options see the [Dyalog for macOS UI Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20UI%20Guide.pdf).
+Display of the session indicator margin can be toggled via `Edit > Preferences > General > Session > Show session margin`.
 
-!!!note
-    The RIDE's UI can vary slightly across different operating systems (and window managers); in particular, RIDE-specific menu bars can be located either within the development environment or in the global menu bar.
+## Status Bar
 
-By default, the Dyalog **Session** user interface includes five elements, as shown in 
-
-![Default GUI, Microsoft Windows](img/screenshots/s_default_gui_windows.png)
-
-- a [caption](caption.md)
-- a [menu bar](menu_bar.md)
-- a [Language bar](language_bar.md)
-- a [Session window](session_window.md)
-- a [Status bar](status_bar.md)
-
-Additional elements can also be present, as shown in :
-
-![Extended GUI](img/screenshots/s_default_gui_windows_extended.png)
-
-- a [workspace explorer](workspace_explorer.md)
-- a [debug information window](debug_information_window.md)
-
-The Dyalog Session user interface with workspace explorer and debug information window displayed (Microsoft Windows)
-
-A [context menu](context_menu.md) is available in the **Session** window, all **Edit** windows and the **Trace** window.
-
-### Caption
-
-The caption at the top of the **Session** window is the name of the Session.
-
-The caption can be [customised](title_tab.md).
-
-### Menu Bar
-
-!!!note "Menu Bar Differences"
-    The menu bar menu options on macOS are different to those on Microsoft Windows and Linux. This section details the options for Microsoft Windows and Linux; for the macOS options see the [Dyalog for macOS UI Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20UI%20Guide.pdf).
-
-The menu names in the menu bar and the options under each menu can be [customised](menu_tab.md).
-
-#### File Menu
-
-The options available under the File menu are detailed below. These control the RIDE‑enabled APL process connections (both on local and remote machines).
+Below it, you will find the status bar which provides situational awareness. Items turn blue if non-default:
 
 | Item | Description |
 | --- | --- |
-| Open... | Prompts for a filename. If a workspace file is selected (a .dws file) then it is loaded into the Session; any other file is opened in the Edit window. Only relevant if the Session was started using the [Start](type_start.md) connection type. |
-| New Session | Starts a new Dyalog Session (a new instance of the interpreter). Only relevant if the Session was started using the [Start](type_start.md) connection type. |
-| Connect… | Opens the RIDE-Dyalog [Session dialog](the_ridedyalog_session_dialog_box.md) box. |
-| Quit | [Terminates](terminating_a_dyalog_session.md) the Dyalog Session. |
+| `&: <number>` | Number of threads currently running (minimum value is 1).|
+| `⎕DQ: <number>` | Number of events in the APL event queue. |
+| `⎕TRAP` | Error trap in effect. |
+| `⎕SI: <number>` | Number of stack frames in the current thread.|
+| `⎕IO: <number>` | Current index origin. |
+| `⎕ML: <number>` | Current migration level.  |
+| `Pos <n>/<n>, <n>` | Cursor position in active window (line number/total lines, column number). |
 
-#### Edit Menu
+## Workspace Explorer
 
-The options available under the Edit menu assist with manipulating text within (and between) windows. They are detailed below.
+The workspace explorer provides a tree view of the current workspace (`#`) and session namespace (`⎕SE`). It can also be used to edit or view any item by double-clicking on the item.
 
-| Item | Description |
-| --- | --- |
-| Undo | Reverses the previous action. |
-| Redo | Reverses the effect of the previous Undo . |
-| Cut | Deletes the selected text from the active window and places it on the clipboard. |
-| Copy | Copies the selected text to the clipboard. |
-| Paste | Pastes the text contents of the clipboard into the active window at the current location. |
-| Find... | Enables a [search](search_and_replace_editwindow.md) for every occurrence of a specified string (this can include APL glyphs) within the code in the active window (Session or Edit). |
-| Find and Replace... | Enables a [search](search_and_replace_editwindow.md) for every occurrence of a specified string (this can include APL glyphs) within the code in the active window (Session or Edit); optionally, a replacement string can be applied on an individual basis. |
-| Preferences | Opens the [Preferences](preferences_dialog_box.md) dialog box. |
+Display of the workspace explorer can be toggled with the `View > Show Workspace Explorer` menu option.
 
-A [context](context_menu.md) menu that includes the Undo, Redo, Cut, Copy and Paste options from the Edit menu is available in the **Session** window, all **Edit** windows and the **Trace** window.
+## Debug Information Window
 
-#### View Menu
+The debug window provides information about currently running threads and the current stack.
 
-The View menu options enable the appearance of the Dyalog Session to be changed.
+The **Threads** area shows each thread's number (`⎕TID`) and name (`⎕TNAME`), its state (for example, `Session`, `Pending`, `:Hold`, `⎕NA`), and which tokens it awaits (`⎕TREQ`). For information on how to use threads, see the [Dyalog Programming Reference Guide](https://docs.dyalog.com/latest/Dyalog%20Programming%20Reference%20Guide.pdf).
 
-| Item | Description |
-| --- | --- |
-| Show Language Bar | Toggles display of the [Language bar](language_bar.md) at the top of the Session window. |
-| Show Status bar | Toggles display of the [Status bar](status_bar.md) at the bottom of the Session window. |
-| Show Workspace Explorer | Toggles display of the [workspace explorer](workspace_explorer.md) to the left of the Session window. |
-| Show Debug | Toggles display of the [debug information window](debug_information_window.md) to the right of the Session window. |
-| Line Wrapping in Session | Toggles line wrapping. When off, `⎕PW` is used to determine line length. When on, a combination of `⎕PW` and line wrapping is used. |
-| Show Status Window | Toggles display of the Status window, which displays system messages and supplementary information. |
-| Auto Status | When checked, displays the Status window when a new message is generated for it. |
-| Stops | Toggles display of an additional column at the left-hand side of the Edit / Trace windows in which break-points can be set/unset. Hiding this column does not remove any previously-set break-points. |
-| Line Numbers | Toggles display of line numbers in the Edit / Trace windows. |
-| Outline | Toggles code folding/outlining for control structures (including `:Section` structures) and functions in Edit windows. When toggled, existing code in an open Edit window is automatically updated to reflect the new rules. |
-| Increase Font Size | Increases the size of the font in all the windows. |
-| Decrease Font Size | Decreases the size of the font in all the windows. |
-| Reset Font Size | Sets the size of the font in all the windows to its default value. |
-| Toggle Full Screen | Toggles the entire session between its current size and full screen size. |
+The **SI Stack** area lists the functions in the execution stack, similar to the display of `)SI`.
 
-#### Window Menu
+Display of the debug information window can be toggled with the `View > Show Debug` menu option.
 
-The option available under the Window menu is detailed below. This closes all open **Edit** and **Trace** windows.
+## Language Bar
 
-| Item | Description |
-| --- | --- |
-| Close All Windows | Closes all open **Edit** and **Trace** windows (the **Session window**, **workspace explorer** and **debug information window** remain open). |
+At the top of the interactive session, you can find the language bar. Click on an APL glyph to type it. You can also hover your mouse over a glyph for a brief description and information about how to type it without using the language bar.
 
-#### Action Menu
+Display of the language bar can be toggled with the `View > Show Language Bar` menu option.
 
-The options available under the **Action** menu enable **Edit** and **Trace** windows to be opened and allow currently-running APL code to be interrupted with trappable events.
+## Keyboard Mappings for APL Glyphs
 
-| Item | Description |
-| --- | --- |
-| Edit | If the cursor is on or immediately after `<object name>` , then opens an **Edit** window on that name. |
-| Trace | In the **Session** window: <ul><li>If the cursor is on a line containing calls to multi-line functions, a **Trace** window is opened and the functions traced (explicit trace)</li><li>If the cursor is on a line containing no text and there is a suspended function (or operator) on the execution stack, open a **Trace** window for that function (naked trace)</li></ul>In a **Trace** window:<ul><li>Open a new Trace window for any multi-line function (or operator) in that line and trace that line as it is evaluated.</li></ul>|
-| Clear all trace/stop/monitor | Removes any trace/stop/monitor flags  (as set by `⎕TRACE` / `⎕STOP` / `⎕MONITOR` ) from all functions in the workspace. |
-| Weak Interrupt | Suspends execution at the start of the next line. |
-| Strong Interrupt | Suspends execution after the current primitive operation. |
-
-#### Threads Menu
-
-The options available under the Threads menu are only relevant when connected to a compatible interpreter. For more information on threads, see the [Dyalog Programming Reference Guide](https://docs.dyalog.com/latest/Dyalog%20Programming%20Reference%20Guide.pdf).
-
-| Item | Description |
-| --- | --- |
-| Pause on Error | Pauses all other threads when a thread suspends due to an error or an interrupt. |
-| Pause all Threads | Pauses all threads (including currently-suspended threads). |
-| Unpause all threads | Unpauses all paused threads (suspended threads remain suspended). |
-| Continue all threads | Resumes all paused threads, restarts all suspended threads, and closes the Trace window. |
-
-#### Help Menu
-
-The options available under the Help menu provide access to the Dyalog documentation, website, and support.
-
-| Item | Description |
-| --- | --- |
-| Getting Started | Opens your default web browser on the [Getting Started](https://www.dyalog.com/getting-started.htm) page of Dyalog Ltd's website. |
-| Dyalog Help | Opens your default web browser on the [Welcome page](https://help.dyalog.com/latest/) of Dyalog's online documentation. |
-| Language Elements | Opens your default web browser on the [Language Elements](https://help.dyalog.com/latest/index.htm#Language/Introduction/Language%20Elements.htm) page of Dyalog's online documentation. |
-| Documentation Centre | Opens your default web browser on the [Documentation Centre](https://www.dyalog.com/documentation_182.htm) page of Dyalog Ltd's website. |
-| Dyalog Website | Opens your default web browser on the [home page](https://www.dyalog.com/) of Dyalog Ltd's website. |
-| Email Dyalog | Opens your email client with a pre-populated template for an email to Dyalog support (including subject line and IDE/interpreter information). |
-| Latest Enhancements | Opens your default web browser on the [Key Features](https://help.dyalog.com/18.2/index.htm#RelNotes18.2/Key%20Features.htm) page of Dyalog's online documentation. |
-| Read Me | Opens your default web browser on the Dyalog [ReadMe](https://docs.dyalog.com/18.2/dyalog_readme.htm) page, containing the latest information about Dyalog. |
-| Third Party Licences | Opens your default web browser on the [Licences](https://help.dyalog.com/18.2/index.htm#MiscPages/Licences%20Overview.htm) for Third-Party Components page of Dyalog's online documentation. |
-| About | Displays the **About** dialog box, which provides details of the current RIDE and connected Dyalog interpreter. |
-
-### Language Bar
-
-The Language bar is located at the top of the **Session** window, beneath the menu bar. It contains buttons for each of the glyphs used as primitives in Dyalog.
-
-When the cursor is positioned over one of the glyphs, information for that glyph is displayed. This includes the name of the glyph, the keyboard shortcut to enter it, its monadic/dyadic name and examples of its syntax, arguments and result.
-
-Clicking on one of the glyphs copies that glyph into the active **Session/Edit** window at the position of the input cursor (the same as typing it directly into the **Session/Edit** window).
-
-The order of glyphs in the Language bar can be customised by using the mouse to drag-and-drop individual glyphs to the required location.
-
-Display of the Language bar can be toggled with the `View > Show Language Bar` menu option or by entering the Toggle Language bar command (`<LBR>`).
-
-On the right hand side of the Language bar is the <img src="../img/screenshots/b_shortcuts.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" />  button:
-
-- Positioning the cursor over the <img src="../img/screenshots/b_shortcuts.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> button displays a dynamic tooltip showing all configured [keyboard shortcuts for command codes](keyboard_shortcuts_and_command_codes.md).
-- Clicking on the  button displays the [Preferences](preferences_dialog_box.md) dialog box (the same as selecting the `Edit > Preferences` menu option).
-
-### Session Window
-
-The primary purpose of the [Session](session_window_input.md) window is to provide a scrolling area within which a user can enter APL expressions and view results.
-
-You can move, resize, maximise and minimise the **Session** window using the standard facilities provided by your operating system.
-
-### Status Bar
-
-The Status bar is located at the bottom of the **Session** window. It contains a button and seven Session status fields, detailed below.
-
-![The Status Bar](img/screenshots/s_Statusbar.png) 
-
-| Item | Description |
-| --- | --- |
-| ![Cog symbol](img/screenshots/i_intext_status.png) | Opens the [Preferences dialog box](preferences_dialog_box.md). |
-| `&: <number>` | Displays the number of threads currently running (minimum value is 1). Turns blue if greater than 1. |
-| `⎕DQ: <number>` | Displays the number of events in the APL event queue. Turns blue if non‑zero. |
-| `⎕TRAP` | Turns blue if `⎕TRAPSI` is set. |
-| `⎕SI: <number>` | Displays the length of `⎕SI` . Turns blue if non‑zero. |
-| `⎕IO: <number>` | Displays the value of `⎕IO` . Turns blue if not equal to the value defined by the Default_IO configuration parameter (default = 1). |
-| `⎕ML: <number>` | Displays the value of `⎕ML` . Turns blue if not equal to the value defined by the Default_ML configuration parameter (default = 1). |
-| `Pos <n>/<n>, <n>` | Displays the location of the cursor in the active window (line number/total lines, column number). |
-
-### Workspace Explorer
-
-The workspace explorer is located to the left of the Session window. It contains a hierarchical tree view of all the namespaces, classes, functions, operators and variables in the active workspace (under `#`) and in the system namespace (under `⎕SE`).
-
-Double-clicking on a namespace, class, function, operator or variable opens its definition in the Edit window.
-
-Display of the workspace explorer can be toggled with the View > Show Workspace Explorer menu option or by entering the Toggle Workspace Explorer command (`<WSE>`).
-
-### Debug Information Window
-
-The debug information window is located to the right of the Session window. It comprises two areas:
-
-- The **Threads** area lists the threads that are currently in existence. For each thread the following information is provided:
-    - a description comprising the thread ID (`⎕TID`) and name (`⎕TNAME`)
-    - the state of the thread, that is, what it is doing (for example, `Session`, `Pending`, `:Hold`, `⎕NA`)
-    - the thread requirements (`⎕TREQ`)
-    - a flag indicating whether the thread is Normal or Paused
-
-        The threads area toobar provides the following functionality: <table style="border-collapse: collapse;margin-left: 0;margin-right: auto;mc-caption-repeat: true;width: auto;">
-        <col />
-        <col />
-        <thead>
-            <tr>
-                <th>Icon</th>
-                <th>Action</th>
-                <th>Description</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td style="text-align: center;">
-                    <img src="../img/screenshots/s_Threadsarea_refresh.png" />
-                </td>
-                <td>Refresh now</td>
-                <td>Refresh the list of threads.</td>
-            </tr>
-            <tr>
-                <td style="text-align: center;">
-                    <img src="../img/screenshots/s_Tracewin_continue.png" />
-                </td>
-                <td>Continue execution of this thread</td>
-                <td>Resume execution of the currently selected thread.</td>
-            </tr>
-            <tr>
-                <td style="text-align: center;">
-                    <img src="../img/screenshots/s_Tracewin_continueall.png" />
-                </td>
-                <td>Continue execution of all threads</td>
-                <td>Resume execution of any paused threads. For information on threads, see the <a href="https://docs.dyalog.com/latest/Dyalog%20Programming%20Reference%20Guide.pdf">Dyalog Programming Reference Guide</a>.</td>
-            </tr>
-        </tbody>
-    </table>
-
-    - The **SI Stack** area lists the functions in the execution stack; each function in the list also has the line number and source code of the line that caused the function to be added to the stack. Equivalent to the result of `)SI`.
-
-Display of the debug information window can be toggled with the View > Show Debug menu option.
-
-### Context Menu
-
-A context menu is available by right-clicking within the **Session**, **Edit** and **Trace** windows. The options available under the context menu are dependent on the window from which it was accessed and are detailed below.
-
-| Item | Description |
-| --- | --- |
-| Fix | **Edit** : Fixes the function without closing the **Edit** window. |
-| Skip to line | **Trace** : Moves the current execution marker to the line on which the cursor is positioned. |
-| Cut | **Session/Edit/Trace** : Deletes the selected text from the active window and places it on the clipboard. Only enabled when text is selected. Never enabled in the **Trace** window. |
-| Copy | **Session/Edit/Trace** : Copies the selected text to the clipboard. Only enabled when text is selected. |
-| Paste | **Session/Edit/Trace** : Pastes the text contents of the clipboard into the active window at the current location. Never enabled in the **Trace** window. |
-| Undo | **Session/Edit/Trace** : Reverses the previous action (where possible). Never enabled in the **Trace** window. |
-| Redo | **Session/Edit/Trace** : Reverses the effect of the previous Undo. Never enabled in the **Trace** window. |
-
-## Keyboard Key Mappings for APL Glyphs
-
-A set of keyboard key mappings for APL glyphs is installed with the RIDE. When the RIDE is the active application, these key mappings are automatically enabled. The RIDE attempts to identify a user's locale and use the appropriate key mappings; if the locale cannot be identified or the locale-specific key mappings have not been configured, then the default configuration is used (key mappings for a US keyboard).
+A set of keyboard key mappings for APL glyphs is installed with RIDE. When RIDE is the active application, these key mappings are automatically enabled. RIDE attempts to identify a user's locale and use the appropriate key mappings; if the locale cannot be identified or the locale-specific key mappings have not been configured, then the default configuration is used (key mappings for a US keyboard).
 
 Using this set of key mappings, APL glyphs are entered by pressing the prefix key followed by either the appropriate key or the SHIFT key with the appropriate key. The prefix key and key mappings can be [customised](keyboard_tab.md).
 
 ### Other Keyboard Options
 
-Installing and enabling a set of key mappings allows Dyalog glyphs to be entered in other applications (for example, email). An alternative set of key mappings can also be used to replace the default key mappings for the RIDE.
+Installing and enabling a set of key mappings allows Dyalog glyphs to be entered in other applications (for example, email). An alternative set of key mappings can also be used to replace the default key mappings for RIDE.
 
 Information and the requisite downloadable files are available from Dyalog's [APL Fonts and Keyboards](https://www.dyalog.com/apl-font-keyboard.htm) page.
 
 !!!note "Microsoft Windows"
-    If you have the Dyalog Unicode IME installed, then the RIDE activates it by default. It can be disabled by unchecking the Also enable Dyalog IME checkbox in the [Keyboard tab](keyboard_tab.md) of the Preferences dialog box.
+    If you have the Dyalog Unicode IME installed, then RIDE activates it by default. It can be disabled by unchecking the Also enable Dyalog IME checkbox in the [Keyboard tab](keyboard_tab.md) of the Preferences dialog box.
 
-    If Dyalog is not installed on the machine that the RIDE is running on, then the Dyalog Unicode IME can be downloaded and installed from Dyalog's [APL Fonts and Keyboards](https://www.dyalog.com/apl-font-keyboard.htm) page.
-
-!!!note "Linux"
-    Most Linux distributions released after mid-2012 support Dyalog glyphs by default. For more information, see the [Dyalog for UNIX Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20UNIX%20Installation%20and%20Configuration%20Guide.pdf).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    If Dyalog is not installed on the machine that RIDE is running on, then the Dyalog Unicode IME can be downloaded and installed from Dyalog's [APL Fonts and Keyboards](https://www.dyalog.com/apl-font-keyboard.htm) page.
 

--- a/docs/working_in_a_dyalog_session.md
+++ b/docs/working_in_a_dyalog_session.md
@@ -1,316 +1,56 @@
 # Working in a Dyalog Session
 
-The main purpose of a development environment is to enable a user to enter and execute expressions; this chapter describes how this can be achieved when running a Dyalog Session through the RIDE and explains the functionality that is provided to simplify the process. 
+The main purpose of a development environment is to enable a user to enter and execute expressions; this chapter describes how this can be achieved when running a Dyalog Session through RIDE and explains the functionality that is provided to simplify the process. 
 
 ## Keyboard Shortcuts and Command Codes
 
-Keyboard shortcuts are keystrokes that execute an action rather than produce a symbol. The RIDE supports numerous keyboard shortcuts, each of which is identified by a command code and mapped to a keystroke combination; for example, the action to open the **Trace** window  is identified by the code **TC** (described in the documentation as `<TC>`). For a complete list of the command codes that can be used in a Dyalog Session running through the RIDE and the keyboard shortcuts for those command codes, see [Keyboard Shortcuts](keyboard_shortcuts.md).
+Keyboard shortcuts are keystrokes that execute an action rather than produce a symbol. RIDE supports numerous keyboard shortcuts, each of which is identified by a command code and mapped to a keystroke combination; for example, the action to open the **Trace** window  is identified by the code **TC** (described in the documentation as `<TC>`). For a complete list of the command codes that can be used in a Dyalog Session running through RIDE and the keyboard shortcuts for those command codes, see [Keyboard Shortcuts](keyboard_shortcuts.md).
 
-Positioning the cursor over the <img src="../img/screenshots/b_shortcuts.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> button on the right hand side of the Language bar displays a dynamic tooltip showing all configured keyboard shortcuts for command codes. Clicking on the <img src="../img/screenshots/b_shortcuts.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> button displays the **Preferences** dialog box (the same as selecting the `Edit > Preferences` menu option), through which keyboard shortcuts can be customised (see [Shortcuts Tab](shortcuts_tab.md)).
+Positioning the cursor over the <img src="../img/screenshots/b_shortcuts.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> button on the right hand side of the Language bar displays a dynamic tooltip showing all configured keyboard shortcuts for command codes. Clicking on the <img src="../img/screenshots/b_shortcuts.png" style="margin-left: 3px;margin-right: 3px;margin-bottom: 0px;height: 12px;" /> button displays the **Preferences** dialog box (the same as selecting the `Edit > Preferences` menu option), through which keyboard shortcuts can be customised (see [Shortcuts Tab](customising_your_session.md/#shortcuts-tab)).
 
-## Navigating the Windows
+## Entering APL Glyphs
 
-When multiple windows are open, the window that has the focus is referred to as the active window. A window can be made the active window by clicking within it.
+APL glyphs can be typed by:
 
-The **Session**, **Edit** and **Trace** windows form a closed loop for the purpose of navigation:
+- typing the glyph in the **Session** window or **Edit** window using the appropriate [key combination](the_dyalog_development_environment.md/#keyboard-mappings-for-apl-glyphs) which is introduced using a prefix key.
+- clicking the appropriate glyph on the [Language bar](the_dyalog_development_environment.md/#language-bar) – this inserts that glyph into the active **Session/Edit** window at the position of the cursor.
 
-- to make the next window in this loop the active window, enter the Tab Window command (`<TB>`)
-- to make the previous window in this loop the active window, enter the Back Tab Window command (`<BT>`)
+If you pause after pressing the prefix key then the autocomplete functionality displays a list of all the glyphs that can be produce together with their full key combinations and their name. If you enter the prefix key a second time then a list of all the glyphs and their full keyboard combinations is again displayed but this time with all the names (formal and informal) that are used for each glyph.
 
-An active **Edit/Trace** window can be closed after changes have been made to its content:
-
-- to save any changes in the content of the active window before closing it, enter the Escape command (`<EP>`), press the  button in its menu bar or, if the window is docked, press  in the window's tab.
-- to discard any changes in the content of the active window before closing it, enter the Quit command (`<QT>`)
-
-## Display of Windows
-
-By default, the Trace window and Edit windows are docked beneath and to the right of the Session window respectively. If the menu option View > Show Workspace Explorer is checked, then the workspace explorer is docked to the far left of any open windows; if the menu option `View > Show Debug` is checked, then the debug information window is docked to the far right of any open windows (see [Session User Interface](session_user_interface.md).
-
-Docked windows can be selected (by clicking within them), resized (by moving the splitter bar) and maximised/minimised (by toggling the icon at the top right of each window).
-
-New Edit and Trace windows can be floating rather than docked by selecting the Floating windows checkbox in the [Windows tab](windows_tab.md) of the Preferences dialog box.
-
-Clicking in the tab of any window enables that window to be dragged to a different location.
-
-## Entering APL Characters
-
-APL glyphs can be entered in a Dyalog Session running through the RIDE by:
-
-- typing the glyph in the Session window or Edit window using the appropriate [key combination](keyboard_key_mappings_for_apl_glyphs.md).
-- clicking the appropriate glyph on the [Language bar](language_bar.md) – this inserts that glyph into the active Session/Edit window at the position of the cursor.
-
-When typing a glyph directly rather than using the Language bar, if you pause after entering the prefix key then the [autocomplete functionality](autocomplete.md) displays a list of all the glyphs that can be produced. If you enter the prefix key a second time then a list of all the glyphs that can be produced is again displayed but this time with the names (formal and informal) that are used for each glyph.
-
-For example:
-
-- `` ` ``      ⍝ default prefix key
-
-The autocomplete functionality list includes the following for the `⍟` glyph:
-
-- ⍟ `* ``logarithm 
-- ⍟ `* ``naturallogarithm
-- ⍟ `* ``circlestar
-- ⍟ `* ``starcircle
-- ⍟ `* ``splat
-
-This means that you can enter the `⍟` glyph by selecting (or directly typing) any of the following:
-
-- `` ` ``*      
-- ``logarithm      
-- ``naturallogarithm
-- ``circlestar      
-- ``starcircle
-- ``splat
-
-As you enter a name, the autocomplete functionality restricts the list of options to those that match the entered name. For example, entering:
-
-- ``ci
-
-restricts the list to:
-
-- ⍟ `` ` ``* ``circlestar
-- ○ `○ ``circular
-- ⌽ `% ``circlestile
-- ⊖ `& ``circlebar
-- ⍉ `^ ``circlebackslash
-- ⍥ `O ``circlediaeresis
-
-## Entering Expressions
-
-The RIDE provides several mechanisms that assist with accuracy and provide clarity when entering expressions in a Dyalog Session, including, *paired enclosures*, *autocomplete*, *context-sensitive help* and *syntax clouring*. These are explained below.
-
-### Paired Enclosures
-
-Applicable in the **Session** window and the **Edit** window
-
-Enclosures in the RIDE include:
-
-- parentheses `( )`
-- braces `{ }`
-- brackets `[ ]`
-
-Angle brackets `< >` are *not* enclosures.
-
-When an opening enclosure character is entered, the RIDE automatically includes its closing pair. This reduces the risk of an invalid expression being entered due to unbalanced enclosures. This feature can be disabled in the General tab of the Preferences dialog box.
-
-### Autocomplete
-
-Applicable in the *Session* window and the I window
-
-The RIDE includes autocomplete functionality for names to reduce the likelihood of errors when including them in an expression (and to save the user having to enter complete names or remember cases for case-sensitive  names).
-
-As a name is entered, the RIDE displays a pop-up window of suggestions based on the characters already entered and the context in which the name is being used.
-
-For example, if you enter a `⎕` character, the pop-up list of suggestions includes all the system names (for example, system functions and system variables). Entering further characters filters the list so that only those system functions and variables that start with the exact string entered are included.
-
-When you start to enter a name in the *Session* window, the pop-up list of suggestions includes all the namespaces, variables, functions and operators that are defined in the current namespace. When you start to enter a name in the *Edit* window, the pop-up list of suggestions also includes all names that are localised in the function header.
-
-To select a name from the pop-up list of suggestions, do one of the following:
-
-- click the mouse on the name in the pop-up list
-- use the right arrow key to select the top name in the pop-up list
-- use the up and down arrow keys to navigate through the suggestions and the right arrow key or the <kbd>tab</kbd> key to enter the currently-highlighted name
-
-The selected name is then completed in the appropriate window.
-
-This feature can be disabled or customised in the General tab of the Preferences dialog box.
-
-### Context-Sensitive Help
-
-Applicable in the **Session** window, **Edit** window and **Trace** window
-
-With the cursor on or immediately after any system command, system name, control structure keyword or primitive glyph, enter the *Help* command (`<HLP>`). The documentation for that system command, system name, control structure keyword or primitive glyph will be displayed.
-
-### Syntax Colouring
-
-Applicable in the **Edit** window and **Trace** window
-
-Syntax colouring assigns different colours to various components, making them easily identifiable. The default syntax colouring convention used is detailed below.
-
-<table style="border-collapse: collapse;margin-left: 0;margin-right: auto;mc-caption-repeat: true;width: auto;">
-    <col />
-    <col />
-    <thead>
-        <tr>
-            <th colspan="2">Colour</th>
-            <th>Syntax</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="background-color:black" width="30">
-            </td>
-            <td>black</td>
-            <td>
-                <p>global names</p>
-                <p>session input/output (unless specified elsewhere)</p>
-            </td>
-        </tr>
-        <tr>
-            <td style="background-color:gray">
-            </td>
-            <td>grey</td>
-            <td>names<br />namespaces<br />numbers<br />tradfn syntax (header line and final <code>∇</code> in scripted syntax)
-            </td>
-        </tr>
-        <tr>
-            <td style="background-color:maroon">
-            </td>
-            <td>maroon</td>
-            <td>control structure keywords</td>
-        </tr>
-        <tr>
-            <td style="background-color:red">
-            </td>
-            <td>red</td>
-            <td>errors (including unmatched parentheses, quotes and braces)</td>
-        </tr>
-        <tr>
-            <td style="background-color:teal">
-            </td>
-            <td>teal</td>
-            <td>strings<br />comments
-            </td>
-        </tr>
-        <tr>
-            <td style="background-color:navy">
-            </td>
-            <td>navy</td>
-            <td>primitive functions<br />zilde
-            </td>
-        </tr>
-        <tr>
-            <td style="background-color:blue">
-            </td>
-            <td>blue</td>
-            <td>idioms (this takes priority over any other syntax colouring)<br />operators<br />parentheses/braces/brackets<br />dfn syntax (specifically, <code>{ } ⍺ ⍵ ∇</code> and <code>:</code>)<br />assignment (<code>←</code>), diamond (<code>⋄</code>) and semi-colon (<code>;</code>)
-            </td>
-        </tr>
-        <tr>
-            <td style="background-color:purple">
-            </td>
-            <td>purple</td>
-            <td>system names</td>
-        </tr>
-    </tbody>
-</table>
-
-The foreground colour and/or the background colour (highlighting) can be customised by syntax type.
+You can select an entry from the list using mouse or keyboard, or keep typing until your desired choice is active, then press <kbd>Tab</kbd> or <kbd>Right Arrow</kbd> to insert it.
 
 ## Executing Expressions
 
-### Executing a New Expression
+RIDE provides several mechanisms that assist with accuracy when entering expressions in a Dyalog Session, including, auto-closing brackets, autocompleting control structures, and highlighting of matching words and brackets. These can be toggled via `Edit > Preferences > Contextual` help.
 
-*Applicable in the **Session** window*
+In the interactive session, you can use the cursor keys to navigate the log. Pressing <kbd>Enter</kbd> re-executes the current line, or all modified lines, if any. Modified lines are restored to their previous state, while their altered versions are copied to the bottom of the session log.
 
-After entering a new expression in the input line, that expression is executed by pressing the <kbd>Enter</kbd> key or with the Enter command (`<ER>`). Following execution, the expression (and any displayed results) become part of the Session log.
+Alternatively, you can recall previously entered expressions using <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Backspace</kbd> for going back in time and <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Enter</kbd> for going forwards in time (configurable via `Edit > Preferences > Shortcuts > BK` and `FD`).
 
-### Re-executing a Previous Expression
-
-*Applicable in the **Session** window*
-
-Instead of entering a new expression in the input line, you can move back through the Session log and re-execute a previously-entered expression.
-
----
-**To re-execute a previously-entered expression**
-
-1. Locate the expression to re-execute in one of the following ways:
-    - Scroll back through the Session log.
-    - Use the Backward command (`<BK>`) and the Forward command (`<FD>`) to cycle backwards and forwards through the input history, successively copying previously-entered expressions into the input line.
-2. Position the cursor anywhere within the expression that you want to re execute and press the <kbd>Enter</kbd> key or use the *Enter* command (`<ER>`).
-
----
-
-If required, a previously-entered expression can be amended prior to execution. In this situation, when the amended expression is executed it is copied to the input line; the original expression in the Session log is not changed. If you start to edit a previous expression and then decide not to, use the *Quit* command (`<QT>`) to return the previous expression to its unaltered state.
-
-### Re-executing Multiple Previous Expressions
-
-*Applicable in the **Session** window*
-
-Multiple expressions can be re-executed together irrespective of whether they were originally executed sequentially (certain system commands cause re‑execution to stop once they have been completed, for example, `)LOAD` and `)CLEAR`).
-
----
-To re-execute multiple previously-entered expressions
-
-1. Locate the first expression to re-execute in one of the following ways:
-    - Scroll back through the Session log.
-    - Use the Backward command (`<BK>`) and the Forward command (`<FD>`) to cycle backwards and forwards through the input history, successively copying previously-entered expressions into the input line.
-2. Change the expression in some way. The change does not have to impact the purpose of the expression; it could be an additional space character.
-3. Scroll through the Session log to locate the next expression to re-execute and change it in some way. Repeat until all the required expressions have been changed.
-4. Press the Enter key or enter the Enter command (`<ER>`).
-
----
-
-The amended expressions are copied to the input line and executed in the order in which they appear in the Session log; the modified expressions in the Session log are restored to their original content.
-
-To re-execute contiguous previously-entered expressions
-
-1. Position the cursor at the start of the first expression to re-execute.
-2. Press and hold the mouse button (left-click) while moving the cursor to the end of the last expression to re-execute.
-3. Copy the selected lines to the clipboard using the Copy command (`<CP>`) or the Cut command (`<CT>`) or the Copy/Cut options in the Edit menu.
-4. Position the cursor in the input line and paste the content of the clipboard back into the Session using the Paste command (`<PT>`), the Paste option in the Edit menu or the Paste option in the context menu.
-5. Press the Enter key or enter the Enter command (`<ER>`).
-
-This technique can also be used to move lines from the Edit window into the Session window and execute them.
+If you set a keyboard shortcut (configurable via `Edit > Preferences > Shortcuts > VAL`) for the "Evaluate selection or name under cursor" action, then you can press your assigned shortcut to do exactly that.
 
 ## Threads
 
-The RIDE supports multithreading. For information on threads, see the Dyalog Programming Reference Guide.
+RIDE supports multithreading. For information on threads, see the [Dyalog Programming Reference Guide](https://docs.dyalog.com/latest/Dyalog%20Programming%20Reference%20Guide.pdf).
 
-The number of threads currently in use is displayed in the Status bar.
+## Setting Stop, Trace, and Monitor points
 
-## Suspending Execution
+For information about stop (breakpoint), trace, and monitor points, see [Stop Controls](https://help.dyalog.com/latest/index.htm#Language/System%20Functions/stop.htm), [Trace Controls](https://help.dyalog.com/latest/index.htm#Language/System%20Functions/trace.htm), and [Monitor Controls](https://help.dyalog.com/latest/index.htm#Language/System%20Functions/monitor.htm).
 
-To assist with investigations into the behaviour of a set of statements (debugging), the system can be instructed to suspend execution just before a particular statement. This is done by setting a *breakpoint*.
+To toggle a Stop point, click in the far left margin of a **Trace** or **Edit** window.
 
-It is sometimes necessary to suspend the execution of a function, for example, if an  endless loop has been inadvertently created or a response is taking an unacceptably long time. This is done using an *interrupt*.
+To toggle a Trace or Monitor point, right-click in that margin and select from the context menu.
 
-Suspended functions can be viewed through the stack; the most recently-referenced function is at the top of the stack. The content of the stack can be queried with the `)SI` system command; this generates a list of all suspended and pendent (that is, awaiting the return of a called function) functions, where suspended functions are indicated by a `*`. For more information on the stack and the state indicator, see the Dyalog Programming Reference Guide.
-
-### Breakpoints
-
-*Applicable in the **Edit** window and the **Trace** window*
-
-When a function that includes a breakpoint is run, its execution is suspended immediately before executing the line on which the breakpoint is set and the **Trace** window is automatically opened (assuming that automatic [trace](trace_window.md) is enabled.
-
-Breakpoints are defined by dyadic `⎕STOP` and can be toggled on and off in an **Edit** or **Trace** window by left-clicking on the far left of the line before which the breakpoint is to be applied or by placing the cursor anywhere in the line before which the breakpoint is to be applied and entering the *Toggle Breakpoint* command (`<BP>`). Note that:
-
-- Breakpoints set or cleared in an **Edit** window are not established until the function is fixed.
-- Breakpoints set or cleared in a **Trace** window are established immediately.
-
-When a breakpoint is reached during code execution, event 1001 is generated; this can be trapped. For more information, see  `⎕TRAP` in the [Dyalog APL Language Reference Guide](https://docs.dyalog.com/latest/Dyalog%20APL%20Language%20Reference%20Guide.pdf).
+Stop, Trace and Monitor points are indicated in the margin with a red circle, a yellow circle, and a clockface, respectively. If more than one type of point has been set on a single code line, a plus icon will be shown instead. 
 
 ### Interrupts
 
-A Dyalog Session running through the RIDE responds to both strong and weak interrupts.
+A Dyalog Session running through RIDE responds to both strong and weak interrupts.
 
-Entering a strong interrupt suspends execution as soon as possible (generally after completing execution of the primitive currently being processed). A strong interrupt is issued by selecting `Actions > Strong Interrupt` in the menu options or by entering the Strong Interrupt command (`<SI>`).
+A strong interrupt suspends execution as soon as possible (generally after completing execution of the primitive currently being processed). A strong interrupt is issued by selecting `Actions > Strong Interrupt`. You can assign a keyboard shortcut for this via `Edit > Preferences > Shortcuts > SI`.
 
-Entering a weak interrupt suspends execution at the start of the next line (generally after completing execution of the statement currently being processed). A weak interrupt is issued by selecting `Actions > Weak Interrupt` in the menu options or by entering the Weak Interrupt command (`<WI>`).
+A weak interrupt suspends execution at the start of the next line (generally after completing execution of the statement currently being processed). A weak interrupt is issued by selecting `Actions > Weak Interrupt` in the menu options or by pressing <kbd>Break</kbd> (usually <kbd>Ctrl</kbd>+<kbd>Pause</kbd>, but configurable via `Edit > Preferences > Shortcuts > WI`).
 
-!!!note
-    When a strong or weak interrupt is issued during code execution, event 1003 or 1002 (respectively) is generated; these can be trapped. For more information, see  `⎕TRAP` in the [Dyalog APL Language Reference Guide](https://docs.dyalog.com/latest/Dyalog%20APL%20Language%20Reference%20Guide.pdf).
+## Terminating a Dyalog Session Running Through RIDE
 
-## Terminating a Dyalog Session Running Through the RIDE
-
-The Dyalog Session can be terminated (without having to close any open windows first) in any of the following ways:
-
-- From the menu options: 
-    - Linux: Select `File > Quit`
-    - macOS: Select `Dyalog > Quit Dyalog`
-    - Microsoft Windows: Select `File > Quit`
-
-- Enter:
-    - Linux: <kbd>Ctrl</kbd> + <kbd>Q</kbd>
-    - macOS : <kbd>⌘</kbd> + <kbd>Q</kbd>
-    - Microsoft Windows: <kbd>Ctrl</kbd> + <kbd>Q</kbd> (only if the Dyalog Unicode IME is not enabled).
-
-In addition, when the **Session** window is the active window, the Dyalog Session can be terminated cleanly in any of the following ways:
-
-- Enter `)OFF`
-- Enter `⎕OFF`
-- Enter `<QIT>`
-- macOS: <kbd>⌘</kbd> + <kbd>W</kbd>
-
-
-
+RIDE will close when the interpreter terminates, including through entering `)OFF` or `⎕OFF` in the interactive session.


### PR DESCRIPTION
Review of chapters 1-7:

1. Remove non-RIDE-specific text (stuff that a computer user can be expected to know, like cut and paste and how to use a search box to search for text)
2. Move to describe _purposes_, not interface and layout
3. Replace Dyalog or APL-specifics independent of RIDE with links to main documentation
4. Change "The RIDE" to just "RIDE" -- just like it's not "The Firefox" or "The Visual Studio"