### PR TITLE
[DOCS] Update the supported platform versions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 !!!note
     RIDE is built on the [Electron](https://www.electronjs.org/) framework. To be able to install the current version of RIDE, your platform must support the Electron major release 26. Consult Electron's [platform support documentation](https://github.com/electron/electron/tree/26-x-y?tab=readme-ov-file#platform-support) if in any doubt.
 
-    RIDE can connect to version 15+ of the Dyalog interpreter.
+    RIDE can connect to version 15.0 or later of the Dyalog interpreter.
 
 ## Font and Keyboard Support
 
@@ -23,7 +23,7 @@ For details, see [Zero Footprint RIDE](starting_a_dyalog_session.md/#zero-footpr
 
 ## Linux
 
-RIDE requires Debian 8+, Fedora 24.04+, or Ubuntu 14.04+. Distributions built on top of the above should also work, provided that they have libnss version 3.26 or newer.
+RIDE requires Debian 8, Fedora 24.04, or Ubuntu 14.04 (or later). Distributions built on top of the above should also work, provided that they have libnss version 3.26 or newer.
 
 1. Download the **.deb** or **.rpm** file (whichever is appropriate for your Linux distribution) from the [RIDE releases page](https://github.com/Dyalog/ride/releases). If your Linux distribution does not support either **.deb** or **.rpm** files, then please contact support@dyalog.com.
 2. From the command line, use standard installation commands to install the package.
@@ -32,7 +32,7 @@ A RIDE shortcut is added to the desktop.
 
 ## macOS
 
-RIDE requires macOS High Sierra (10.13) or better.
+RIDE requires macOS High Sierra (10.13) or later.
 
 The RIDE is the default UI for Dyalog on macOS and is installed at the same time as Dyalog (see the [Dyalog for macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)); no further installation is required.
 
@@ -48,7 +48,7 @@ Starting RIDE will add RIDE's icon to the temporary "Recently Used Apps" area to
 
 ## Windows
 
-RIDE requires Windows 10 or newer.
+RIDE requires Windows 10 or later.
 
 1. Download the **.zip** file from the [RIDE releases page](https://github.com/Dyalog/ride/releases).
 2. Unzip the downloaded **.zip** file, placing the `setup_ride.exe` and `setup_ride.msi` files in the same location as each other.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,9 +2,9 @@
 
 
 !!!note
-    RIDE is built on the [Electron](https://www.electronjs.org/) framework. To be able to install the current version of RIDE, your platform must support the Electron major release 26. Consult Electron's [platform support documentation](https://github.com/electron/electron/tree/26-x-y?tab=readme-ov-file#platform-support) if in any doubt.
+    RIDE is built on the [Electron](https://www.electronjs.org/) framework. To install this version of RIDE, your platform must support the Electron major release 26. Consult Electron's [platform support documentation](https://github.com/electron/electron/tree/26-x-y?tab=readme-ov-file#platform-support) if in any doubt.
 
-    RIDE can connect to version 15.0 or later of the Dyalog interpreter.
+    This version of RIDE can connect to version 15.0 or later of the Dyalog interpreter.
 
 ## Font and Keyboard Support
 
@@ -34,7 +34,7 @@ A RIDE shortcut is added to the desktop.
 
 RIDE requires macOS High Sierra (10.13) or later.
 
-The RIDE is the default UI for Dyalog on macOS and is installed at the same time as Dyalog (see the [Dyalog for macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)); no further installation is required.
+RIDE is the default UI for Dyalog on macOS and is installed at the same time as Dyalog (see the [Dyalog for macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)); no further installation is required.
 
 You can also install RIDE as a separate, stand-alone, product, for example to work exclusively with remote APL interpreters:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,11 @@
 # Installation
 
+
+!!!note
+    RIDE is built on the [Electron](https://www.electronjs.org/) framework. To be able to install the current version of RIDE, your platform must support the Electron major release 26. Consult Electron's [platform support documentation](https://github.com/electron/electron/tree/26-x-y?tab=readme-ov-file#platform-support) if in any doubt.
+
+    RIDE can connect to version 15+ of the Dyalog interpreter.
+
 ## Font and Keyboard Support
 
 If Dyalog is not installed on the machine that RIDE is being installed on, then the APL385 Unicode font and keyboard mappings installed with RIDE mean that they are available within RIDE. However, to be able to enter APL glyphs outside RIDE, see [APL Fonts and Keyboards](https://www.dyalog.com/apl-font-keyboard.htm).
@@ -17,7 +23,7 @@ For details, see [Zero Footprint RIDE](starting_a_dyalog_session.md/#zero-footpr
 
 ## Linux
 
-RIDE requires Debian 8+, Fedora 14.04+, or Ubuntu 10.10+. Distributions built on top of the above should also work, provided that they have libnss version 3.26 or newer.
+RIDE requires Debian 8+, Fedora 24.04+, or Ubuntu 14.04+. Distributions built on top of the above should also work, provided that they have libnss version 3.26 or newer.
 
 1. Download the **.deb** or **.rpm** file (whichever is appropriate for your Linux distribution) from the [RIDE releases page](https://github.com/Dyalog/ride/releases). If your Linux distribution does not support either **.deb** or **.rpm** files, then please contact support@dyalog.com.
 2. From the command line, use standard installation commands to install the package.
@@ -26,7 +32,7 @@ A RIDE shortcut is added to the desktop.
 
 ## macOS
 
-RIDE requires macOS Yosemite (10.10) or better.
+RIDE requires macOS High Sierra (10.13) or better.
 
 The RIDE is the default UI for Dyalog on macOS and is installed at the same time as Dyalog (see the [Dyalog for macOS Installation and Configuration Guide](https://docs.dyalog.com/latest/Dyalog%20for%20macOS%20Installation%20and%20Configuration%20Guide.pdf)); no further installation is required.
 
@@ -42,7 +48,7 @@ Starting RIDE will add RIDE's icon to the temporary "Recently Used Apps" area to
 
 ## Windows
 
-RIDE requires Windows 7 or newer.
+RIDE requires Windows 10 or newer.
 
 1. Download the **.zip** file from the [RIDE releases page](https://github.com/Dyalog/ride/releases).
 2. Unzip the downloaded **.zip** file, placing the `setup_ride.exe` and `setup_ride.msi` files in the same location as each other.

--- a/readme-docs.md
+++ b/readme-docs.md
@@ -1,5 +1,14 @@
 # Building the docs
 
+## Pre-flight
+
+If you're about to push out a new docs release, check the following first:
+
+1. Are the version statements in the "installation.md" page still valid? If the version of Electron has been bumped, this page must be checked.
+
+
+## Build process
+
 The documentation for Ride lives at https://dyalog.github.io/ride. It is a GitHub Pages site, built with [mkdocs](https://www.mkdocs.org/), using the [material theme](https://squidfunk.github.io/mkdocs-material/).
 
 Install the following components:


### PR DESCRIPTION
* The supported platform versions were for an older version of Electron.
* Add reference to Electron's supported platform statements for v26
* Re-add minimum Dyalog version requirement.