### PR TITLE
Better signposting for zero footprint RIDE

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,16 +10,16 @@
 
 If Dyalog is not installed on the machine that RIDE is being installed on, then the APL385 Unicode font and keyboard mappings installed with RIDE mean that they are available within RIDE. However, to be able to enter APL glyphs outside RIDE, see [APL Fonts and Keyboards](https://www.dyalog.com/apl-font-keyboard.htm).
 
-## Zero-Footprint
+## RIDE in the Browser
 
-The use of RIDE from a browser requires no installation on the machine where RIDE will run; all you need is a  modern browser.
+The use of RIDE from a browser requires no installation on the machine where RIDE will run; all you need is a  modern browser. This is known as "zero-footprint RIDE".
 
 !!!note
     When installing RIDE, if you select the default location suggested by the installer then APL can be launched as a RIDE server without creating a [configuration file](sample_configuration_file.md).
 
 On non-Windows platforms, zero-footprint RIDE is automatically installed to the default location (**[DYALOG]/RIDEapp**) when Dyalog is installed and no additional installation is necessary. On Windows, zero-footprint RIDE needs separate installation.
 
-For details, see [Zero Footprint RIDE](starting_a_dyalog_session.md/#zero-footprint-mode).
+For details, see [RIDE in the browser](ride_in_the_browser.md).
 
 ## Linux
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -7,6 +7,6 @@ RIDE is a cross-platform, graphical development environment capable of producing
 
 RIDE runs separately from the APL interpreter, but can communicate with any local or remote APL session. It can launch APL sessions on remote machines or to connect to APL interpreters that are already running.
 
-An interpreter can also provide RIDE's interface as a web page. This makes it possible to control a remote interpreter thorugh a browser, without installing RIDE on your machine. For this zero-footprint mode to work on Windows, RIDE needs to be installed on the machine where the interpreter is running, however, it comes with the interpreter installation on all other platforms.
+An interpreter can also provide [RIDE's interface as a web page](ride_in_the_browser.md). This makes it possible to control a remote interpreter thorugh a browser, without installing RIDE on your machine. For this zero-footprint mode to work on Windows, RIDE needs to be installed on the machine where the interpreter is running, however, it comes with the interpreter installation on all other platforms.
 
 On Windows, the interpreter has a built-in IDE, which continues to provide the richest environment, however, RIDE the recommended interface on all other platforms.

--- a/docs/ride_in_the_browser.md
+++ b/docs/ride_in_the_browser.md
@@ -11,9 +11,9 @@ This mode has the following limitations:
 
 ## Accessing Zero-Footprint RIDE from a browser
 
-1. If on Windows, [install zero-footprint RIDE](installation.md/#windows)
+1. If Dyalog is running on Windows, [install zero-footprint RIDE](installation.md/#windows)
 2. Set the `RIDE_INIT` configuration parameter to `HTTP:address:port` (see [RIDE Init](ridespecific_language_features.md/#ride_init)), for example, `RIDE_INIT=HTTP:*:8080`.
 3. Start a Dyalog session.
 4. Navigate to `http://<address>:<port>`, for example, `http://10.0.38.1:8080`.
 
-On non-Windows platforms, the interpreter expects to find zero-footprint RIDE installed at the `[DYALOG]/RIDEapp` directory; this removes the need to include the `HTTPDIR` field in a [configuration file](installation.md#configuration-ini-file).
+If Dyalog is running on non-Windows platforms, the interpreter expects to find zero-footprint RIDE installed at the `[DYALOG]/RIDEapp` directory; this removes the need to include the `HTTPDIR` field in a [configuration file](installation.md#configuration-ini-file).

--- a/docs/ride_in_the_browser.md
+++ b/docs/ride_in_the_browser.md
@@ -1,0 +1,19 @@
+# RIDE in the browser
+
+Dyalog can serve RIDE to any modern web browser – this is known as "zero-footprint" operation since RIDE is not installed on the client machine but is downloaded by the web browser on demand. The advantage is that an APL session can be monitored and maintained from any device without installing anything.
+
+This mode has the following limitations:
+
+- You can only interact with the APL interpreter that is serving you; the **New Session** window is not available.
+- Preferences are persisted in browser storage using cookies.
+- Window captions cannot be controlled.
+- The floating **Trace/Edit** windows option is not available.
+
+## Accessing Zero-Footprint RIDE from a browser
+
+1. If on Windows, [install zero-footprint RIDE](installation.md/#windows)
+2. Set the `RIDE_INIT` configuration parameter to `HTTP:address:port` (see [RIDE Init](ridespecific_language_features.md/#ride_init)), for example, `RIDE_INIT=HTTP:*:8080`.
+3. Start a Dyalog session.
+4. Navigate to `http://<address>:<port>`, for example, `http://10.0.38.1:8080`.
+
+On non-Windows platforms, the interpreter expects to find zero-footprint RIDE installed at the `[DYALOG]/RIDEapp` directory; this removes the need to include the `HTTPDIR` field in a [configuration file](installation.md#configuration-ini-file).

--- a/docs/ridespecific_language_features.md
+++ b/docs/ridespecific_language_features.md
@@ -62,7 +62,7 @@ where `mode` is the action that the interpreter should take and determines the c
 - `SERVE` – listen for incoming connections from a RIDE client
 - `CONNECT` – attempt to connect to the specified RIDE client and end the session if this fails
 - `POLL` – attempt to connect to the specified RIDE client at regular intervals and reconnect if the connection is lost
-- `HTTP` – listen for incoming connections from the web browser, via [zero footprint RIDE](starting_a_dyalog_session.md/#zero-footprint-mode)
+- `HTTP` – listen for incoming connections from the web browser, via [Zero Footprint RIDE](ride_in_the_browser.md)
 - `CONFIG` – retrieve values to use from a .ini [configuration file](installation.md/#configuration-ini-file)
 
 !!!note
@@ -106,7 +106,7 @@ To establish a connection using the settings in the ride_sample.ini file:`RIDE_I
 
 To attempt to establish a secure connection with a RIDE client running on a different machine (with IPv4 address 10.0.38.1 and listening on port 4502) using certificate details specified in the ride_sample.ini file: `RIDE_INIT=CONFIG:C:\tmp\ride_sample.ini,CONNECT:10.0.38.1:4502` or `RIDE_INIT=CONNECT:10.0.38.1:4502,CONFIG:C:\tmp\ride_sample.ini`
 
-With Dyalog and RIDE installed on a machine with IPv4 address 10.0.38.1, to listen on port 4502 for connection requests from a web browser running on any machine ([Zero Footprint RIDE](starting_a_dyalog_session.md/#the-zero-footprint-ride)): `RIDE_INIT=HTTP:*:4502`
+With Dyalog and RIDE installed on a machine with IPv4 address 10.0.38.1, to listen on port 4502 for connection requests from a web browser running on any machine ([RIDE in the browser](ride_in_the_browser.md)): `RIDE_INIT=HTTP:*:4502`
 
 To open the Zero Footprint RIDE in a web browser on:
 

--- a/docs/starting_a_dyalog_session.md
+++ b/docs/starting_a_dyalog_session.md
@@ -16,7 +16,7 @@ When running a Dyalog Session through RIDE, the Session can be:
     - The operating system on which the remote interpreter is running is irrelevant – the instructions given in this chapter apply to the operating system on which RIDE is running (the two operating systems do not have to be the same).
     - The remote machine does not need to have RIDE installed but the Dyalog Session must be [RIDE-enabled](ridespecific_language_features.md/#ride_init).
 
-Normally, connections between RIDE and interpreters are initialised from the **New Session** screen. The exception to this is zero-footprint use, which always requires Dyalog to be started first with suitable configuration parameters, after which RIDE will appear when you direct a web browser at the APL interpreter. See [Zero Footprint Ride](#zero-footprint-mode) for details.
+Normally, connections between RIDE and interpreters are initialised from the **New Session** screen. The exception to this is zero-footprint use, which always requires Dyalog to be started first with suitable configuration parameters, after which RIDE will appear when you direct a web browser at the APL interpreter. See [RIDE in the browser](ride_in_the_browser.md) for details.
 
 
 ## New Session window
@@ -42,22 +42,3 @@ For example:
 
 Click <kbd>OK</kbd> to connect, start, or begin listening — per the current settings.
 
-## Zero-Footprint Mode
-
-Dyalog can serve RIDE to any modern web browser – this is known as "zero-footprint" operation since RIDE is not installed on the client machine but is downloaded by the web browser on demand. The advantage is that an APL session can be monitored and maintained from any device without installing anything.
-
-This mode has the following limitations:
-
-- You can only interact with the APL interpreter that is serving you; the **New Session** window is not available.
-- Preferences are persisted in browser storage using cookies.
-- Window captions cannot be controlled.
-- The floating **Trace/Edit** windows option is not available.
-
-### Accessing Zero-Footprint RIDE from a browser
-
-1. If on Windows, [install zero-footprint RIDE](installation.md/#windows)
-2. Set the `RIDE_INIT` configuration parameter to `HTTP:address:port` (see [RIDE Init](ridespecific_language_features.md/#ride_init)), for example, `RIDE_INIT=HTTP:*:8080`.
-3. Start a Dyalog session.
-4. Navigate to `http://<address>:<port>`, for example, `http://10.0.38.1:8080`.
-
-On non-Windows platforms, the interpreter expects to find zero-footprint RIDE installed at the `[DYALOG]/RIDEapp` directory; this removes the need to include the `HTTPDIR` field in a [configuration file](installation.md#configuration-ini-file).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - introduction.md
   - installation.md
   - "Starting a Session": starting_a_dyalog_session.md
+  - ride_in_the_browser.md
   - the_dyalog_development_environment.md
   - input_windows.md
   - working_in_a_dyalog_session.md


### PR DESCRIPTION
"Zero footprint" is a non-obvious thing to search for. Therefore:

* Make 0fpr a toplevel section called "RIDE in the browser"
* Link to it from the Introduction page
* Update references