### PR TITLE
1236 dependencies

### DIFF
--- a/CI/packagescripts/linux/packageLinux.sh
+++ b/CI/packagescripts/linux/packageLinux.sh
@@ -146,9 +146,9 @@ createDEB() {
 		-C ${SBOXDIR}				\
 		-d 'libc6 >= 2.17'			\
 		-d 'libnss3 >= 3.26'			\
+		-d 'libgbm1'				\
 		-d 'libgtk-3-0'				\
 		-d 'libxss1'				\
-		-d 'libgconf-2-4'			\
 		-d 'libasound2'				\
 		-d 'libx11-xcb1'			\
 		--license "MIT"			\
@@ -187,8 +187,8 @@ createRPM() {
 		-C ${SBOXDIR}				\
 		-d 'libc.so.6(GLIBC_2.17)(64bit)'	\
 		-d 'libXss.so.1()(64bit)'		\
+		-d 'libgbm.so.1()(64bit)'		\
 		-d 'libgtk-3.so.0()(64bit)'		\
-		-d 'libgconf-2.so.4()(64bit)'		\
 		-d 'libasound.so.2()(64bit)'		\
 		-d 'libnss3.so()(64bit)'		\
 		-d 'libX11-xcb.so.1()(64bit)'		\

--- a/CI/packagescripts/linux/packageLinux.sh
+++ b/CI/packagescripts/linux/packageLinux.sh
@@ -242,6 +242,7 @@ for CPUTYPE in x64 armv7l ; do
 	#find "${SBOXDIR}" -name ".git*" | xargs rm -r # for lintian
 	find "${SBOXDIR}" -type f "(" -name ".*" -o -name "*.c" ")" | xargs rm # for rpmlint
 	find "${SBOXDIR}" -xtype l | xargs rm -f # remove dangling symlinks, for rpmlint
+	chmod 4755 ${SBOXDIR}/opt/ride-${BASE_VERSION}/chrome-sandbox
 
 	mkdir -p ${SBOXDIR}/usr/share/icons/hicolor/scalable/apps
 	cp "$ICON" ${SBOXDIR}/usr/share/icons/hicolor/scalable/apps/ride${BASE_VERSION_ND}.svg


### PR DESCRIPTION
Update Linux dependencies & fix permission issue with chrome-sandbox

This fixes #1236 allowing Ride 4.6 to both install and to run on ubuntu 24.04 - The deb files have also been tested on ubuntu 18.04 / 20.04 / 22.04, and the RPM was tested on OpenSuse Leap 15.5 (AndyS)

We should also back-port this to Ride-4.5 (and a release pushed) as currently there's no released version that will work on ubuntu 24.04.