### PR TITLE
reset language bar action

### DIFF
--- a/src/km.js
+++ b/src/km.js
@@ -299,7 +299,10 @@
     ZMI() { D.prf.zoom(Math.min(12, D.prf.zoom() + 1)); },
     ZMO() { D.prf.zoom(Math.max(-10, D.prf.zoom() - 1)); },
     ZMR() { D.prf.zoom(0); },
-
+    RLB() {
+      D.db.setItem('lbarOrder', D.lb.order);
+      D.ide.lbarRecreate();
+    },
   });
 
   const pfKey = (i) => () => D.ide.pfKey(i);

--- a/src/km.js
+++ b/src/km.js
@@ -300,7 +300,7 @@
     ZMO() { D.prf.zoom(Math.max(-10, D.prf.zoom() - 1)); },
     ZMR() { D.prf.zoom(0); },
     RLB() {
-      D.db.setItem('lbarOrder', D.lb.order);
+      D.prf.lbarOrder(D.lb.order);
       D.ide.lbarRecreate();
     },
   });

--- a/src/km.js
+++ b/src/km.js
@@ -299,10 +299,7 @@
     ZMI() { D.prf.zoom(Math.min(12, D.prf.zoom() + 1)); },
     ZMO() { D.prf.zoom(Math.max(-10, D.prf.zoom() - 1)); },
     ZMR() { D.prf.zoom(0); },
-    RLB() {
-      D.prf.lbarOrder(D.lb.order);
-      D.ide.lbarRecreate();
-    },
+    RLB() { D.prf.lbarOrder(D.lb.order); },
   });
 
   const pfKey = (i) => () => D.ide.pfKey(i);

--- a/src/prf.js
+++ b/src/prf.js
@@ -136,6 +136,8 @@ D.prf = {};
     + '\n  Clear all trace/stop/monitor =CAM'
     + '\n  Weak Interrupt           =WI'
     + '\n  Strong Interrupt         =SI'
+    + '\n  -'
+    + '\n  Reset Language Bar       =RLB'
     + '\n&Threads                        {rp21}'
     + '\n  Pause on Error           =POE'
     + '\n  Pause all Threads        =PAT'


### PR DESCRIPTION
A take on [issue #1022](https://github.com/Dyalog/ride/issues/1022)

I added a new menu item under "Action" called "Reset Language Bar". I then added a new command called "RLB" that sets `lbarOrder`, which seems to be specified here `D.lb.order`. Lastly, we recreate the language bar.

**Please forgive me if I did something stupid, I'd be more than happy to accommodate feedback.**

**1. Custom Layout + Menu Button**
![reset-lb-1](https://github.com/Dyalog/ride/assets/30244485/28d0586b-325a-4dc4-8926-59b71da55efa)

**2. After RLB Button Click**
![reset-lb-2](https://github.com/Dyalog/ride/assets/30244485/eaeb23d1-2f8c-4f01-b1e0-0e6710d306b8)
