### PR TITLE
Fix autocomplete suggestions

### DIFF
--- a/src/mon_apl.js
+++ b/src/mon_apl.js
@@ -673,41 +673,8 @@
         if (t === 'for' || t === 'while' || t === 'repeat') {
           suggestions.push(...['Continue', 'Leave'].map(textItem));
         }
-        if (t === 'class' || t === 'namesapce') {
+        if (t === 'class' || t === 'namespace') {
           suggestions.push(
-            {
-              label: 'Class',
-              kind: kind.Snippet,
-              insertText: [
-                'Class ${1:name}',
-                '\t$0',
-                ':EndClass',
-              ].join('\n'),
-              insertTextRules,
-              documentation: 'Class script',
-            },
-            {
-              label: 'Namespace',
-              kind: kind.Snippet,
-              insertText: [
-                'Namespace ${1:name}',
-                '\t$0',
-                ':EndNamespace',
-              ].join('\n'),
-              insertTextRules,
-              documentation: 'Namespace script',
-            },
-            {
-              label: 'Interface',
-              kind: kind.Snippet,
-              insertText: [
-                'Interface ${1:name}',
-                '\t$0',
-                ':EndInterface',
-              ].join('\n'),
-              insertTextRules,
-              documentation: 'Interface script',
-            },
             {
               label: 'Property',
               kind: kind.Snippet,
@@ -723,21 +690,21 @@
               insertTextRules,
               documentation: 'Property declaration',
             },
-            {
-              label: 'Section',
-              kind: kind.Snippet,
-              insertText: [
-                'Section ${1:name}',
-                '\t$0',
-                ':EndSection',
-              ].join('\n'),
-              insertTextRules,
-              documentation: 'Section block',
-            },
           );
         }
         // if (!t || t === '∇') {
         suggestions.push(
+          {
+            label: 'Class',
+            kind: kind.Snippet,
+            insertText: [
+              'Class ${1:name}',
+              '\t$0',
+              ':EndClass',
+            ].join('\n'),
+            insertTextRules,
+            documentation: 'Class script',
+          },
           {
             label: 'Disposable',
             kind: kind.Snippet,
@@ -785,6 +752,28 @@
             documentation: 'If-Else Statement',
           },
           {
+            label: 'Interface',
+            kind: kind.Snippet,
+            insertText: [
+              'Interface ${1:name}',
+              '\t$0',
+              ':EndInterface',
+            ].join('\n'),
+            insertTextRules,
+            documentation: 'Interface script',
+          },
+          {
+            label: 'Namespace',
+            kind: kind.Snippet,
+            insertText: [
+              'Namespace ${1:name}',
+              '\t$0',
+              ':EndNamespace',
+            ].join('\n'),
+            insertTextRules,
+            documentation: 'Namespace script',
+          },
+          {
             label: 'Repeat',
             kind: kind.Snippet,
             insertText: [
@@ -805,6 +794,17 @@
             ].join('\n'),
             insertTextRules,
             documentation: 'Repeat loop until',
+          },
+          {
+            label: 'Section',
+            kind: kind.Snippet,
+            insertText: [
+              'Section ${1:name}',
+              '\t$0',
+              ':EndSection',
+            ].join('\n'),
+            insertTextRules,
+            documentation: 'Section block',
           },
           {
             label: 'Select',

--- a/src/mon_apl.js
+++ b/src/mon_apl.js
@@ -676,6 +676,43 @@
         if (t === 'class' || t === 'namespace') {
           suggestions.push(
             {
+              label: 'Class',
+              kind: kind.Snippet,
+              insertText: [
+                'Class ${1:name}',
+                '\t$0',
+                ':EndClass',
+              ].join('\n'),
+              insertTextRules,
+              documentation: 'Class script',
+            },
+            {
+              label: 'Namespace',
+              kind: kind.Snippet,
+              insertText: [
+                'Namespace ${1:name}',
+                '\t$0',
+                ':EndNamespace',
+              ].join('\n'),
+              insertTextRules,
+              documentation: 'Namespace script',
+            },
+            {
+              label: 'Interface',
+              kind: kind.Snippet,
+              insertText: [
+                'Interface ${1:name}',
+                '\t$0',
+                ':EndInterface',
+              ].join('\n'),
+              insertTextRules,
+              documentation: 'Interface script',
+            },
+          );
+        }
+        if (t === 'class') {
+          suggestions.push(
+            {
               label: 'Property',
               kind: kind.Snippet,
               insertText: [
@@ -694,17 +731,6 @@
         }
         // if (!t || t === '∇') {
         suggestions.push(
-          {
-            label: 'Class',
-            kind: kind.Snippet,
-            insertText: [
-              'Class ${1:name}',
-              '\t$0',
-              ':EndClass',
-            ].join('\n'),
-            insertTextRules,
-            documentation: 'Class script',
-          },
           {
             label: 'Disposable',
             kind: kind.Snippet,
@@ -750,28 +776,6 @@
             ].join('\n'),
             insertTextRules,
             documentation: 'If-Else Statement',
-          },
-          {
-            label: 'Interface',
-            kind: kind.Snippet,
-            insertText: [
-              'Interface ${1:name}',
-              '\t$0',
-              ':EndInterface',
-            ].join('\n'),
-            insertTextRules,
-            documentation: 'Interface script',
-          },
-          {
-            label: 'Namespace',
-            kind: kind.Snippet,
-            insertText: [
-              'Namespace ${1:name}',
-              '\t$0',
-              ':EndNamespace',
-            ].join('\n'),
-            insertTextRules,
-            documentation: 'Namespace script',
           },
           {
             label: 'Repeat',

--- a/src/mon_apl.js
+++ b/src/mon_apl.js
@@ -710,7 +710,7 @@
             },
           );
         }
-        if (t === 'class') {
+        if (t === 'class' || t === 'interface') {
           suggestions.push(
             {
               label: 'Property',


### PR DESCRIPTION
A take on [issue #753](https://github.com/Dyalog/ride/issues/753)

These autocomplete suggestions were already in code but they were hidden behind an `if` block and were only shown, if the previous token was `class` or `namespace` but the latter had a typo.

So I fixed the typo and also ensured that `:Property` only shows within a `:Class` and `:Interface` definitions.

Lastly, `:Section` is available as a default suggestion, if I read the documentation correct [here](https://docs.dyalog.com/latest/Dyalog%20Programming%20Reference%20Guide.pdf) (p.104), `:Section` are for readability and are allowed within both function and class definitions.  

**Please forgive me if I did something stupid, I'd be more than happy to accommodate feedback.**