### PR TITLE
Colour ⍛ as valid dyadic operator.

### DIFF
--- a/src/mon_apl.js
+++ b/src/mon_apl.js
@@ -518,7 +518,7 @@
               } else if ((m = sm.match(/^[/\\⌿⍀¨⍨⌸⌶&]+/))) {
                 addToken(offset, 'keyword.operator.monadic');
                 offset += m[0].length;
-              } else if ((m = sm.match(/^[.∘⍤⍥⍣⍠@⌺]+/))) {
+              } else if ((m = sm.match(/^[.∘⍤⍥⍣⍠@⌺⍛]+/))) {
                 addToken(offset, 'keyword.operator.dyadic');
                 offset += m[0].length;
               } else {


### PR DESCRIPTION
As of version 20.0.50217, the interpreter recognises ⍛ as the [Behind](https://aplwiki.com/wiki/Reverse_Compose) dyadic operator. Update Ride's syntax colouring code to be aware of this.