### PR TITLE
Trace primitives support

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -213,7 +213,9 @@ When the user presses `<ER>` (Enter) or `<TC>` (Ctrl-Enter), Ride sends
 ["Execute",{"text":"      1 2 3+4 5 6","trace":1}] // Ride -> Interpreter
 ```
 * `text`: the APL code to evaluate
-* `trace`: 0 or 1, whether the expression should be evaluated in the tracer (`<TC>`)
+* `trace`: 0 = execute
+           1 = evaluate in the tracer (`<TC>`)
+           2 = evaluate in the tracer token by token (`<TP>`)
 
 Note that Ride can't assume that everything entered in the session will be echoed, e.g. quote quad input (`⍞`) doesn't
 echo.  Therefore, Ride should wait for the [`EchoInput`](#EchoInput) message.
@@ -343,8 +345,9 @@ The following messages are used in relation to trace windows.
 
 ### SetHighlightLine <a name=SetHighlightLine></a>
 This tells Ride where the currently executed line is.  Traditionally that's indicated by a red border around it.
+Optionally, provides start and length of token to highlight with `tbt_start` and `tbt_len`.
 ```json
-["SetHighlightLine",{"win":123,"line":45}] // Interpreter -> Ride
+["SetHighlightLine",{"win":123,"line":45, "tbt_start": 3, "tbt_len": 1}] // Interpreter -> Ride
 ```
 
 ### SetLineAttributes <a name=SetLineAttributes></a>
@@ -416,6 +419,12 @@ Request the current line in a trace window is executed. (Step over)
 ["StepInto",{"win":123}] // Ride -> Interpreter
 ```
 Request the current line in a trace window is executed. (Step into)
+
+### TraceToken <a name=TraceToken></a>
+```json
+["TraceToken",{"win":123}] // Ride -> Interpreter
+```
+Request the current line in a trace window is executed token but token.
 
 
 ## Status Bar

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -65,6 +65,7 @@ D.cmds = [
   ['STL','Skip to line',            []],
   ['TB', 'Tab between windows',     ['Ctrl+Tab']],
   ['TC', 'Trace line',              ['Ctrl+Enter']],
+  ['TP', 'Trace token',             ['Ctrl+Alt+Enter']],
   ['TGC','Toggle comment',          []],
   ['TIP','Show value tip',          []],
   ['TL', 'Toggle localisation',     ['Ctrl+Up']],

--- a/src/cmds.js
+++ b/src/cmds.js
@@ -65,7 +65,7 @@ D.cmds = [
   ['STL','Skip to line',            []],
   ['TB', 'Tab between windows',     ['Ctrl+Tab']],
   ['TC', 'Trace line',              ['Ctrl+Enter']],
-  ['TP', 'Trace token',             ['Ctrl+Alt+Enter']],
+  ['TP', 'Trace primitives',        ['Ctrl+Alt+Enter']],
   ['TGC','Toggle comment',          []],
   ['TIP','Show value tip',          []],
   ['TL', 'Toggle localisation',     ['Ctrl+Up']],

--- a/src/ed.js
+++ b/src/ed.js
@@ -232,20 +232,21 @@ D.Ed.prototype = {
     if (!line) {
       ed.hlDecorations = [];
     } else {
-      ed.hlDecorations = [{
-        range: new monaco.Range(line, 1, line, 1),
-        options: {
-          isWholeLine: true,
-          className: 'highlighted',
-        },
-      }];
       if (tbtStart > 0) {
-        ed.hlDecorations.push({
+        ed.hlDecorations = [{
           range: new monaco.Range(line, tbtStart, line, tbtStart + tbtLen),
           options: {
-            inlineClassName: 'highlighted_token',
+            inlineClassName: 'highlighted',
           },
-        });
+        }];
+      } else {
+        ed.hlDecorations = [{
+          range: new monaco.Range(line, 1, line, 1),
+          options: {
+            isWholeLine: true,
+            className: 'highlighted',
+          },
+        }];
       }
       me.setPosition({ lineNumber: line, column: 1 });
       me.revealLineInCenter(line);

--- a/src/ed.js
+++ b/src/ed.js
@@ -227,6 +227,7 @@ D.Ed.prototype = {
     const ed = this;
     const { me } = ed;
     const { line, tbtStart, tbtLen } = ed.HIGHLIGHT || {};
+    if (!me.getModel()) return; // sometimes window is closed just before this is called
     ed.dom.classList.toggle('tbt', tbtStart > 0);
     if (!line) {
       ed.hlDecorations = [];
@@ -365,6 +366,7 @@ D.Ed.prototype = {
     const ed = this;
     const { me } = ed;
     const model = me.getModel();
+    if (!model) return; // sometimes window is closed just after an UpdateWindow
     ed.name = ee.name;
     // Check if a filename for a source file is provided.
     // Make sure it isn't duplicated in the existing name.
@@ -423,6 +425,7 @@ D.Ed.prototype = {
   },
   update(x) {
     const ed = this;
+    ed.firstOpen = true;
     ed.container && ed.container.setTitle(x.name);
     ed.me_ready.then(() => ed.open(x));
   },
@@ -557,7 +560,7 @@ D.Ed.prototype = {
       u.lineNumber = ed.HIGHLIGHT.line;
     }
     if (ed.firstOpen) {
-      if (lines.length === 1 && /\s?[a-z|@]+$/.test(lines[0])) u.column = model.getLineContent(u.lineNumber).length + 1;
+      if (lines.length === 1 && /\s?[a-z|@]+$/.test(lines[0])) u.column = model.getLineContent(1).length + 1;
       else if (lines[0][0] === ':') u.column = 1;
       else u.column = 2;
       ed.firstOpen = false;

--- a/src/ed.js
+++ b/src/ed.js
@@ -231,21 +231,20 @@ D.Ed.prototype = {
     if (!line) {
       ed.hlDecorations = [];
     } else {
+      ed.hlDecorations = [{
+        range: new monaco.Range(line, 1, line, 1),
+        options: {
+          isWholeLine: true,
+          className: 'highlighted',
+        },
+      }];
       if (tbtStart > 0) {
-        ed.hlDecorations = [{
+        ed.hlDecorations.push({
           range: new monaco.Range(line, tbtStart, line, tbtStart + tbtLen),
           options: {
-            inlineClassName: 'highlighted',
+            inlineClassName: 'highlighted_token',
           },
-        }];
-      } else {
-        ed.hlDecorations = [{
-          range: new monaco.Range(line, 1, line, 1),
-          options: {
-            isWholeLine: true,
-            className: 'highlighted',
-          },
-        }];
+        });
       }
       me.setPosition({ lineNumber: line, column: 1 });
       me.revealLineInCenter(line);

--- a/src/ed.js
+++ b/src/ed.js
@@ -569,7 +569,7 @@ D.Ed.prototype = {
   SetHighlightLine(line, hadErr, tbtStart, tbtLen) {
     const ed = this;
     ed.HIGHLIGHT = { line, tbtStart, tbtLen };
-    ed.me_ready.then(() => ed.hl(line + 1, tbtStart + 1, tbtLen));
+    ed.me_ready.then(() => ed.hl(line, tbtStart, tbtLen));
     hadErr < 0 && ed.focus();
   },
   ValueTip(x) {

--- a/src/ed.js
+++ b/src/ed.js
@@ -400,7 +400,7 @@ D.Ed.prototype = {
     if (/(\.|\\|\/)/.test(ee.name)) {
       me.setModel(monaco.editor.createModel(ed.oText, null, monaco.Uri.file(ee.name)));
     } else {
-      monaco.editor.setModelLanguage(model, ed.isCode && !ed.isReadOnlyEntity ? 'apl' : 'plaintext');
+      monaco.editor.setModelLanguage(model, ed.isCode ? 'apl' : 'plaintext');
       ed.dom.classList.remove('charmat', 'chararr', 'numarr', 'mixarr', 'charvecvec', 'quador', 'charvec');
       etype && ed.dom.classList.add(etype);
     }

--- a/src/ide.js
+++ b/src/ide.js
@@ -644,7 +644,7 @@ D.IDE = function IDE(opts = {}) {
     },
     SetHighlightLine(x) {
       const w = D.wins[x.win];
-      w.SetHighlightLine(x.line, ide.hadErr);
+      w.SetHighlightLine(x.line + 1, ide.hadErr, x.tbt_start + 1, x.tbt_len);
       ide.hadErr > 0 && (ide.hadErr -= 1);
       D.prf.wse() && ide.wse.refresh();
       ide.focusWin(w);

--- a/src/km.js
+++ b/src/km.js
@@ -352,7 +352,7 @@
         (h && h[x]) ? h.execCommand(x) : $.alert(`Command ${x} not implemented.`);
     });
   };
-  ('CLS CBP MA AC VAL indentOrComplete indentMoreOrAutocomplete STL TVO TVB'
+  ('CLS CBP MA AC TP VAL indentOrComplete indentMoreOrAutocomplete STL TVO TVB'
   + ' TGC JBK JSC LOG WSE').split(' ').forEach(defCmd);
   for (let i = 0; i < C.length; i++) {
     if (C[i]) {
@@ -400,7 +400,7 @@
         if (cmd === 'FX') { fxkbs.push(nkc); return; }
         if (cmd === 'ER') {
           cond = 'tracer && !editorHasMultipleSelections && !findInputFocussed && !inSnippetMode';
-        } else if (cmd === 'TC') {
+        } else if (cmd === 'TC' || cmd === 'TP') {
           cond = 'tracer';
         } else if (cmd === 'LL' || cmd === 'RL') {
           cond = '!suggestWidgetVisible && !findInputFocussed';

--- a/src/prf_col.js
+++ b/src/prf_col.js
@@ -293,7 +293,9 @@
     ],
     'Editor/Tracer': [
       { s: 'Active tracer', t: 'tc', c: '/*noprefix*/.tracer .monaco-editor-background,/*noprefix*/.tracer .monaco-editor .margin', bg: 1 },
-      { s: 'Pendent tracer', t: 'tcpe', c: '/*noprefix*/.tracer.pendent .monaco-editor-background,/*noprefix*/.tracer.pendent .monaco-editor .margin', bg: 1 },
+      { s: 'Pendent tracer', t: 'tcpe',
+      c: '/*noprefix*/.tracer.pendent .monaco-editor-background,/*noprefix*/.tracer.pendent .monaco-editor .margin,'
+       + '/*noprefix*/.tracer.tbt .monaco-editor-background,/*noprefix*/.tracer.tbt .monaco-editor .margin', bg: 1 },
       { s: 'Vector of character vectors', t: 'cvv', c: '.charvecvec', bg: 1, fg: 1, BIU: 1 },
       { s: 'Simple numeric array ', t: 'na', c: '.numarr', bg: 1, fg: 1, BIU: 1 },
       { s: 'Simple character matrix', t: 'cm', c: '.charmat', bg: 1, fg: 1, BIU: 1 },

--- a/src/se.js
+++ b/src/se.js
@@ -759,6 +759,7 @@ D.Se.prototype = {
   EP() { this.ide.focusMRUWin(); },
   ER() { this.exec(0); },
   TC() { this.exec(1); },
+  TP() { this.exec(2); },
   LN() { D.prf.lineNums.toggle(); },
   MA() { D.send('RestartThreads', {}); }, // Threads > Restart All Threads
   VAL() {

--- a/style/less/colour/monaco.less
+++ b/style/less/colour/monaco.less
@@ -50,6 +50,9 @@
   border:none;
   outline:solid @ME_HIGHLIGHTED 1px;
 }
+.highlighted_token{
+  background-color: fade(@ME_HIGHLIGHTED,20);
+}
 .sessionmargin{
   border-right: 1px solid @GLYPHMARGIN_BRD_COL;
   font-size: 1em;

--- a/style/less/colour/monaco.less
+++ b/style/less/colour/monaco.less
@@ -51,7 +51,7 @@
   outline:solid @ME_HIGHLIGHTED 1px;
 }
 .highlighted_token{
-  background-color: fade(@ME_HIGHLIGHTED,20);
+  background-color: fade(lighten(@ME_HIGHLIGHTED,20),50);
 }
 .sessionmargin{
   border-right: 1px solid @GLYPHMARGIN_BRD_COL;

--- a/style/less/colour/monaco.less
+++ b/style/less/colour/monaco.less
@@ -46,13 +46,19 @@
     text-shadow: 1px 1px black,-1px -1px black,1px -1px black,-1px 1px black;
   }
 }
-.highlighted{
-  border:none;
-  outline:solid @ME_HIGHLIGHTED 1px;
+.highlighted:not(:has(+ .highlighted)) { // single token
+	box-shadow: inset -1px -1px @ME_HIGHLIGHTED, inset 1px 1px @ME_HIGHLIGHTED;
 }
-.highlighted_token{
-  background-color: fade(lighten(@ME_HIGHLIGHTED,20),50);
+.highlighted:has(+ .highlighted) { // first token
+	box-shadow: inset 0 -1px @ME_HIGHLIGHTED, inset 1px 1px @ME_HIGHLIGHTED;
 }
+.highlighted + .highlighted{ // middle token
+	box-shadow: inset 0px -1px @ME_HIGHLIGHTED, inset 0px 1px @ME_HIGHLIGHTED;
+}
+.highlighted + .highlighted:not(:has(+ .highlighted)){ // last token
+	box-shadow: inset -1px -1px @ME_HIGHLIGHTED, inset 0px 1px @ME_HIGHLIGHTED;
+}
+
 .sessionmargin{
   border-right: 1px solid @GLYPHMARGIN_BRD_COL;
   font-size: 1em;


### PR DESCRIPTION
Adds support for `TP` Trace Primitives command.
This will also highlight the current primitive correctly instead of just the line, but no support added yet for opening up accessory windows to show left/right/function/result.