### PR TITLE
Add support for APLAN

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -250,6 +250,13 @@ to request opening an editor.  `pos` is the 0-based position of the cursor in `t
 :red_circle: "Edit" must be extended to submit the current content of all dirty windows, otherwise jumping from one
 method to another in a class will obliterate the current changes.
 
+### ShowAsArrayNotation <a name=ShowAsArrayNotation></a>
+When user clicks on button `[⋄]` in an editor window for a variable that can be edited as APLAN, Ride should send;
+```json
+["ShowAsArrayNotation",{"win":123}] // Ride -> Interpreter
+```
+to request an update to the window with content changed to array notation. The interpreter will respond with a separate `UpdateWindow` command.
+
 ### OpenWindow <a name=OpenWindow></a>
 The interpreter will parse that and may respond later with one of;
 ```json
@@ -275,8 +282,8 @@ Constants for `entityType`:
 | `4` |  simple numeric array | | `512` |  APL class
 | `8` |  mixed simple array | | `1024` |  APL interface
 | `16` |  nested array | | `2048` |  APL session
-| `32` |  [`⎕OR`](http://help.dyalog.com/latest/Content/Language/System%20Functions/or.htm) object | | `4096` |  external function.
-| `64` |  native file
+| `32` |  [`⎕OR`](http://help.dyalog.com/latest/Content/Language/System%20Functions/or.htm) object | | `4096` |  external function
+| `64` |  native file | | `262144` | array notation (APLAN)
 
 :red_circle: TODO: describe the other arguments
 

--- a/index.html
+++ b/index.html
@@ -361,6 +361,16 @@
         </g>
       </svg>
     </a>
+    <a href=# class='tb_btn tb_EDA var_only' title='Edit in Array Notation'>
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+        xml:space="preserve" overflow="hidden" viewBox="2070 718 242 242">
+        <g>
+          <path fill="currentColor"
+            d="M2190.45 795.737 2154.4 838.039 2190.45 878.967 2224.58 838.039ZM2191 764.422C2193.39 764.422 2204.67 776.005 2224.85 799.17 2245.03 822.336 2255.12 835.292 2255.12 838.039 2255.12 840.969 2245.08 853.833 2224.99 876.632 2204.9 899.431 2193.57 910.831 2191 910.831 2187.7 910.831 2176.14 899.569 2156.32 877.044 2136.51 854.52 2126.6 841.518 2126.6 838.039 2126.6 834.742 2136.51 821.649 2156.32 798.758 2176.14 775.868 2187.7 764.422 2191 764.422ZM2244.94 718 2297.78 718C2302.55 718 2305.99 719.608 2308.1 722.824 2310.21 726.04 2311.27 729.762 2311.27 733.988 2311.27 861.142 2311.45 926.42 2311.82 929.819 2312.18 933.218 2312 934.918 2311.27 934.918 2312 946.864 2310.72 954.03 2307.41 956.416 2304.84 958.805 2298.24 959.909 2287.6 959.725 2285.76 959.909 2283.01 960 2279.34 960 2275.67 960 2264.21 959.909 2244.94 959.725 2238.89 959.725 2235.77 955.33 2235.58 946.54 2235.77 938.849 2238.89 935.004 2244.94 935.004L2287.32 935.004 2287.32 741.898 2244.94 741.898C2238.15 741.898 2234.76 737.915 2234.76 729.949 2234.76 721.983 2238.15 718 2244.94 718ZM2084.22 718 2137.06 718C2143.85 718 2147.24 721.983 2147.24 729.949 2147.24 737.915 2143.85 741.898 2137.06 741.898L2094.68 741.898 2094.68 935.004 2137.06 935.004C2143.11 935.004 2146.23 938.849 2146.42 946.54 2146.23 955.33 2143.11 959.725 2137.06 959.725 2117.79 959.909 2106.33 960 2102.66 960 2098.99 960 2096.24 959.909 2094.4 959.725 2083.76 959.909 2077.16 958.805 2074.59 956.416 2071.28 954.03 2070 946.864 2070.73 934.918 2070 934.918 2069.82 933.218 2070.18 929.819 2070.55 926.42 2070.73 861.142 2070.73 733.988 2070.73 729.762 2071.79 726.04 2073.9 722.824 2076.01 719.608 2079.45 718 2084.22 718Z"
+            fill-rule="evenodd" />
+        </g>
+      </svg>
+    </a>
     <a href=# class='tb_btn tb_EP ed_only' title='Save changes and close editor'>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
         <g id="level-1">
@@ -405,7 +415,7 @@
         </g>
       </svg>
     </a>
-    <a href=# class='tb_btn tb_CBP' title='Clear stops for this object'>
+    <a href=# class='tb_btn tb_CBP code_only' title='Clear stops for this object'>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
         <g id="level-1">
           <g class="cls-1">
@@ -424,13 +434,13 @@
         </g>
       </svg>
     </a>
-    <span class='tb_sep ed_only'></span>
-    <a href=# class='tb_btn tb_AO ed_only' title='Comment selected text'>
+    <span class='tb_sep ed_only code_only'></span>
+    <a href=# class='tb_btn tb_AO ed_only code_only' title='Comment selected text'>
       <span class="fa-layers">
         <span class="fa-layers-text" data-fa-transform="grow-4 up-3" style="font-family:apl">⍝</span>
       </span>
     </a>
-    <a href=# class='tb_btn tb_DO ed_only' title='Uncomment selected text'>
+    <a href=# class='tb_btn tb_DO ed_only code_only' title='Uncomment selected text'>
       <span class="fa-layers">
         <span class="fa-layers-text" data-fa-transform="grow-4 up-3" style="font-family:apl">⍝</span>
         <span class="fas fa-circle" data-fa-transform="shrink-8 down-3 left-3" style="color:red"></span>

--- a/style/less/layout/tracer.less
+++ b/style/less/layout/tracer.less
@@ -11,9 +11,12 @@
 .no-toolbar .toolbar {
   display:none;
 }
-.tracer .toolbar .ed_only{display:none}
+.tracer .toolbar .ed_only,
+.variable .toolbar .code_only,
+        .toolbar .var_only,
         .toolbar .tc_only{display:none}
-.tracer .toolbar .tc_only{
+.tracer .toolbar .tc_only,
+.variable .toolbar .var_only{
   display: inline-block;
   &.tb_sep {
     display:inline;


### PR DESCRIPTION
* Add button `[⋄]` to editor window when open on variable that can be edited as array notation.
* Support APLAN in tokenizer