### PR TITLE
New minimum electron version 34.0.1 -> 34.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ava": "^5.3.1",
     "cheerio": "^1.0.0-rc.12",
     "compression": "^1.7.4",
-    "electron": "^34.0.1",
+    "electron": "^34.5.0",
     "electron-connect": "^0.6.3",
     "eslint": "^8.46.0",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
This should not be a big risk. Those of us who build ride ourselves likely end up with 34.5 because that is what ^34.0.1 with a ^ will happily resolve to.

This difference in versions does resolve the issue seen with paste in #1304 . I believe I (at least) didn't have any problems because I had a higher version than 34.0.1