### PR TITLE
Exit Multiline Input

### DIFF
--- a/src/cmds.js
+++ b/src/cmds.js
@@ -27,6 +27,7 @@ D.cmds = [
   ['DMR','Load demo file',          []],
   ['DOX','Documentation Centre',    []],
   ['DO', 'Uncomment lines',         []],
+  ['EMI','Exit multiline input',    []],
   ['ED', 'Edit',                    ['Shift+Enter']],
   ['EP', 'Exit (and save changes)', ['Escape']],
   ['ER', 'Execute line',            ['Enter']],

--- a/src/ed.js
+++ b/src/ed.js
@@ -611,6 +611,7 @@ D.Ed.prototype = {
   EDA() {
     D.send('ShowAsArrayNotation', { win: this.id });
   },
+  EMI() {},
   QT() { D.send('CloseWindow', { win: this.id }); },
   BK(me) { this.tc ? D.send('TraceBackward', { win: this.id }) : me.trigger('D', 'undo'); },
   FD(me) { this.tc ? D.send('TraceForward', { win: this.id }) : me.trigger('D', 'redo'); },

--- a/src/km.js
+++ b/src/km.js
@@ -352,7 +352,7 @@
         (h && h[x]) ? h.execCommand(x) : $.alert(`Command ${x} not implemented.`);
     });
   };
-  ('CLS CBP MA AC IT VAL indentOrComplete indentMoreOrAutocomplete STL TVO TVB'
+  ('CLS CBP EMI MA AC IT VAL indentOrComplete indentMoreOrAutocomplete STL TVO TVB'
   + ' TGC JBK JSC LOG WSE').split(' ').forEach(defCmd);
   for (let i = 0; i < C.length; i++) {
     if (C[i]) {

--- a/src/se.js
+++ b/src/se.js
@@ -88,11 +88,15 @@ D.Se = function Se(ide) { // constructor
   me.onMouseDown((e) => {
     const t = e.target;
     const mt = monaco.editor.MouseTargetType;
+    const p = t.position;
     if (e.event.middleButton) {
       e.event.preventDefault();
       e.event.stopPropagation();
+    } else if (t.type === mt.GUTTER_GLYPH_MARGIN) {
+      if (se.promptType === 3 && p.lineNumber === se.lines.length + 1) {
+        D.send('ExitMultilineInput', {});
+      }
     } else if (t.type === mt.CONTENT_TEXT) {
-      const p = t.position;
       const l = p.lineNumber;
       const c = p.column;
       if (e.event.timestamp - mouseTS < 400 && mouseL === l && mouseC === c) {
@@ -502,7 +506,7 @@ D.Se.prototype = {
         range: new monaco.Range(li + 2, 1, li + 2, 1),
         options: {
           isWholeLine: false,
-          glyphMarginClassName: 'group_end',
+          glyphMarginClassName: 'group_end cancelable',
           stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
         },
       });

--- a/src/se.js
+++ b/src/se.js
@@ -93,8 +93,8 @@ D.Se = function Se(ide) { // constructor
       e.event.preventDefault();
       e.event.stopPropagation();
     } else if (t.type === mt.GUTTER_GLYPH_MARGIN) {
-      if (se.promptType === 3 && p.lineNumber === se.lines.length + 1) {
-        D.send('ExitMultilineInput', {});
+      if (p.lineNumber === se.lines.length + 1) {
+        this.EMI();
       }
     } else if (t.type === mt.CONTENT_TEXT) {
       const l = p.lineNumber;
@@ -771,6 +771,7 @@ D.Se.prototype = {
     se.hl();
   },
   CLS() {},
+  EMI() { if (this.promptType === 3) D.send('ExitMultilineInput', {}); },
   EP() { this.ide.focusMRUWin(); },
   ER() { this.exec(0); },
   TC() { this.exec(1); },

--- a/style/less/colour/monaco.less
+++ b/style/less/colour/monaco.less
@@ -66,13 +66,39 @@
   border-right: 1px solid @GLYPHMARGIN_BRD_COL;
   font-size: 1em;
   &.group_start::before{
-    content: '┌';
+    content: ' ';
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' aria-hidden='true' role='img'%3E%3Cpolyline points='192,512 192,256 320,256' fill='none' stroke='black' stroke-width='1px' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E");
+    width: 100%;
+    height: 100%;
   }
   &.group_middle::before{
-    content: '│';
+    content: ' ';
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' aria-hidden='true' role='img'%3E%3Cpolyline points='192,0 192,512' fill='none' stroke='black' stroke-width='1px' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E");
+    width: 100%;
+    height: 100%;
   }
   &.group_end::before{
-    content: '└';
+    content: ' ';
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' aria-hidden='true' role='img'%3E%3Cpolyline points='192,0 192,256 320,256' fill='none' stroke='black' stroke-width='1px' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E");
+    width: 100%;
+    height: 100%;
+  }
+  &.group_end.cancelable::before{
+    content: ' ';
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' aria-hidden='true' role='img'%3E%3Cpolyline points='192,0 192,256 320,256' fill='none' stroke='black' stroke-width='1px' vector-effect='non-scaling-stroke'/%3E%3Cg transform='translate(256 128) scale(0.5, 0.5)'%3E%3Cpath fill='blue' d='M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z'/%3E%3C/g%3E%3Cg transform='translate(312 160) scale(0.375, 0.375)'%3E%3Cpath fill='white' d='M323.1 441l53.9-53.9c9.4-9.4 9.4-24.5 0-33.9L279.8 256l97.2-97.2c9.4-9.4 9.4-24.5 0-33.9L323.1 71c-9.4-9.4-24.5-9.4-33.9 0L192 168.2 94.8 71c-9.4-9.4-24.5-9.4-33.9 0L7 124.9c-9.4 9.4-9.4 24.5 0 33.9l97.2 97.2L7 353.2c-9.4 9.4-9.4 24.5 0 33.9L60.9 441c9.4 9.4 24.5 9.4 33.9 0l97.2-97.2 97.2 97.2c9.3 9.3 24.5 9.3 33.9 0z'/%3E%3C/g%3E%3C/svg%3E");
+    width: 100%;
+    height: 100%;
+  }
+  &.group_end.cancelable:hover::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' aria-hidden='true' role='img'%3E%3Cpolyline points='192,0 192,256 320,256' fill='none' stroke='black' stroke-width='1px' vector-effect='non-scaling-stroke'/%3E%3Cg transform='translate(256 128) scale(0.5, 0.5)'%3E%3Cpath fill='red' d='M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z'/%3E%3C/g%3E%3Cg transform='translate(312 160) scale(0.375, 0.375)'%3E%3Cpath fill='white' d='M323.1 441l53.9-53.9c9.4-9.4 9.4-24.5 0-33.9L279.8 256l97.2-97.2c9.4-9.4 9.4-24.5 0-33.9L323.1 71c-9.4-9.4-24.5-9.4-33.9 0L192 168.2 94.8 71c-9.4-9.4-24.5-9.4-33.9 0L7 124.9c-9.4 9.4-9.4 24.5 0 33.9l97.2 97.2L7 353.2c-9.4 9.4-9.4 24.5 0 33.9L60.9 441c9.4 9.4 24.5 9.4 33.9 0l97.2-97.2 97.2 97.2c9.3 9.3 24.5 9.3 33.9 0z'/%3E%3C/g%3E%3C/svg%3E");
   }
   &.modified:not(.group_start,.group_middle,.group_end)::before{
     content: '∙';


### PR DESCRIPTION
Adds support to exit multiline input via:
1. Clicking on cross on outline in margin
2. Assigning keyboard shortcut `EMI` and executing it in session

Fixes #1323 