### PR TITLE
`exes` must be an array - addresses unpredictable UI for connections

### DIFF
--- a/src/cn.js
+++ b/src/cn.js
@@ -1021,7 +1021,7 @@
           q.exes_dtl.hidden = sel.preset;
           q.type.value = sel.type || 'connect';
           q.subtype.value = sel.subtype || 'raw';
-          interpretersSSH = sel.exes || [];
+          interpretersSSH = Array.isArray(sel.exes) ? sel.exes : [];
           updFormDtl();
           updExes();
           q.fav_name.value = sel.name || '';


### PR DESCRIPTION
The error propagates as UI weirdness.

This doesn't address why or how invalid exes can get in and have got in to config files, but rather just ignores invalid exes when they are found.