### PR TITLE
Correctly colour classic versions of ⌺ and ⍛

### DIFF
--- a/src/syntax_info.js
+++ b/src/syntax_info.js
@@ -8,7 +8,7 @@
   s.letter = 'A-Z_a-zÀ-ÖØ-Ýß-öø-üþ∆⍙Ⓐ-Ⓩ';
   s.name = `(?:[${s.letter}][${s.letter}\\d]*)`;
   s.sysfns = ' a á af ai an arbin arbout arg at av avu base c class clear cmd cr cs csv ct cy d dct df div dl dm dmx dq dr dt ea ec ed em en env es et ex exception export fappend favail fc fchk fcopy fcreate fdrop ferase fhist fhold fix flib fmt fnames fnums fprops fr frdac frdci fread frename freplace fresize fsize fstac fstie ftie funtie fx inp instances io json kl l lc load lock lx map mkdir ml monitor na nappend nc ncopy ncreate ndelete nerase new nexists nget ninfo nl nlock nmove nnames nnums nparts nput nq nr nread nrename nreplace nresize ns nsi nsize ntie null nuntie nxlate off opt or path pfkey pp pr profile ps pt pw r refs rl rsi rtl s save sd se sh shadow si signal size sm sr src stack state stop svc sve svo svq svr svs syl tc tcnums tf tget this tid tkill tname tnums tpool tput trace trap treq ts tsync tz ucs ul using vfi vr wa wc wg wn ws wsid wx x xml xsi xt'.split(' ');
-  s.sysfns_classic = 'u2286 u2338 u233a u2360 u2364 u2365 u2378'.split(' ');
+  s.sysfns_classic = 'u2286 u2338 u233a u235b u2360 u2364 u2365 u2378'.split(' ');
 
   s.scmd = 'classes clear cmd continue copy cs drop ed erase events fns holds intro lib load methods ns objects obs off ops pcopy props reset save sh sic si sinl tid vars wsid xload'.split(' ');
 

--- a/src/syntax_info.js
+++ b/src/syntax_info.js
@@ -8,7 +8,7 @@
   s.letter = 'A-Z_a-zÀ-ÖØ-Ýß-öø-üþ∆⍙Ⓐ-Ⓩ';
   s.name = `(?:[${s.letter}][${s.letter}\\d]*)`;
   s.sysfns = ' a á af ai an arbin arbout arg at av avu base c class clear cmd cr cs csv ct cy d dct df div dl dm dmx dq dr dt ea ec ed em en env es et ex exception export fappend favail fc fchk fcopy fcreate fdrop ferase fhist fhold fix flib fmt fnames fnums fprops fr frdac frdci fread frename freplace fresize fsize fstac fstie ftie funtie fx inp instances io json kl l lc load lock lx map mkdir ml monitor na nappend nc ncopy ncreate ndelete nerase new nexists nget ninfo nl nlock nmove nnames nnums nparts nput nq nr nread nrename nreplace nresize ns nsi nsize ntie null nuntie nxlate off opt or path pfkey pp pr profile ps pt pw r refs rl rsi rtl s save sd se sh shadow si signal size sm sr src stack state stop svc sve svo svq svr svs syl tc tcnums tf tget this tid tkill tname tnums tpool tput trace trap treq ts tsync tz ucs ul using vfi vr wa wc wg wn ws wsid wx x xml xsi xt'.split(' ');
-  s.sysfns_classic = 'u2286 u2338 u233A u2360 u2364 u2365 u2378'.split(' ');
+  s.sysfns_classic = 'u2286 u2338 u233a u2360 u2364 u2365 u2378'.split(' ');
 
   s.scmd = 'classes clear cmd continue copy cs drop ed erase events fns holds intro lib load methods ns objects obs off ops pcopy props reset save sh sic si sinl tid vars wsid xload'.split(' ');
 


### PR DESCRIPTION
As #1378 describes, the classic versions of ⌺ and ⍛ are coloured as error tokens - correct this.